### PR TITLE
Double proof body limit from 16k to 32k

### DIFF
--- a/crev-data/src/proof/mod.rs
+++ b/crev-data/src/proof/mod.rs
@@ -359,7 +359,7 @@ impl Serialized {
                             self.body += line;
                             self.body += "\n";
                         }
-                        if self.body.len() > 16_000 {
+                        if self.body.len() > 32_000 {
                             bail!("Proof body too long");
                         }
                     }


### PR DESCRIPTION
Quick workaround for crev-dev/cargo-crev#246

Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] ~~Modify `CHANGELOG.md` if applicable~~
  * CHANGELONG.md is currently a placeholder...?