### PR TITLE
Fix help message for 'id query'

### DIFF
--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -488,7 +488,7 @@ pub enum Id {
     #[structopt(name = "distrust", alias = "d")]
     Distrust(IdTrust),
 
-    /// Distrust an Id
+    /// Query Ids
     #[structopt(name = "query", alias = "q")]
     Query(IdQuery),
 }


### PR DESCRIPTION
Looks like a bad copy&paste:
```
$ cargo crev id
cargo-crev-id 0.10.1
[...]
SUBCOMMANDS:
    current     Show your current Id
    distrust    Distrust an Id
[...]
    query       Distrust an Id
```