### PR TITLE
Pin ed25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ dependencies = [
  "common_failures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crev-common 0.13.0",
  "derive_builder 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -769,14 +769,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -891,14 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1626,7 +1624,7 @@ dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pmac 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2474,7 +2472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle"
-version = "2.1.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3056,6 +3054,11 @@ name = "zeroize"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "zeroize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
@@ -3122,7 +3125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 "checksum curl 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ed9a22aa8c4e49ac0c896279ef532a43a7df2f54fcd19fa36960de029f965f"
 "checksum curl-sys 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5e90ae10f635645cba9cad1023535f54915a95c58c44751c6ed70dbaeb17a408"
-"checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
+"checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
 "checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
 "checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
@@ -3135,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
+"checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum encoding_rs_io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9619ee7a2bf4e777e020b95c1439abaf008f8ea8041b78a0552c4f1bcf4df32c"
@@ -3312,7 +3315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01f40907d9ffc762709e4ff3eb4a6f6b41b650375a3f09ac92b641942b7fb082"
+"checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
@@ -3377,3 +3380,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
+"checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"

--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED](https://github.com/dpc/crev/compare/cargo-crev-v0.12.0...cargo-crev-v0.13.0) - UNRELEASED
+## Fixed
+
+* `cargo install` works without `--locked` flag
+
 ## [0.13.0](https://github.com/dpc/crev/compare/cargo-crev-v0.12.0...cargo-crev-v0.13.0) - 2019-11-26
 ## Changed
 

--- a/cargo-crev/src/dyn_proof.rs
+++ b/cargo-crev/src/dyn_proof.rs
@@ -1,7 +1,6 @@
 use common_failures::Result;
-use crev_data::proof::CommonOps;
 use crev_data::{
-    proof::{self, ContentExt},
+    proof::{self, CommonOps, ContentExt},
     OwnId, PubId,
 };
 use failure::bail;

--- a/cargo-crev/src/info.rs
+++ b/cargo-crev/src/info.rs
@@ -1,14 +1,14 @@
-use crate::deps::scan;
-use crate::deps::AccumulativeCrateDetails;
-use crate::opts::{CrateSelector, CrateVerify, CrateVerifyCommon};
-use crate::Repo;
+use crate::{
+    deps::{scan, AccumulativeCrateDetails},
+    opts::{CrateSelector, CrateVerify, CrateVerifyCommon},
+    Repo,
+};
 use common_failures::Result;
 use crev_common::convert::OptionDeref;
 use crev_data::proof;
 use failure::bail;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::io;
+use std::{collections::HashSet, io};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/crev-common/src/lib.rs
+++ b/crev-common/src/lib.rs
@@ -16,8 +16,8 @@ use blake2::{digest::FixedOutput, Digest};
 use failure::format_err;
 use rpassword;
 use rprompt;
-use std::collections::HashSet;
 use std::{
+    collections::HashSet,
     env,
     ffi::OsString,
     io::{self, BufRead, Read, Write},

--- a/crev-data/Cargo.toml
+++ b/crev-data/Cargo.toml
@@ -17,9 +17,9 @@ common_failures = "0.1"
 crev-common = { path = "../crev-common", version = "0.13.0" }
 derive_builder = "0.7"
 typed-builder = "0.3"
-ed25519-dalek = "1.0.0-pre.2"
+ed25519-dalek = "=1.0.0-pre.3"
 failure = "0.1"
-rand = "0.6"
+rand = "0.7"
 semver = { version = "0.9", features = [ "serde" ] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"

--- a/crev-data/src/id.rs
+++ b/crev-data/src/id.rs
@@ -183,8 +183,7 @@ impl OwnId {
     }
 
     pub fn generate(url: Url) -> Self {
-        let mut csprng: OsRng = OsRng::new().unwrap();
-        let keypair = ed25519_dalek::Keypair::generate(&mut csprng);
+        let keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
         Self {
             id: PubId::new_from_pubkey(keypair.public.as_bytes().to_vec(), url),
             keypair,

--- a/crev-data/src/proof/mod.rs
+++ b/crev-data/src/proof/mod.rs
@@ -15,8 +15,7 @@ pub mod review;
 pub mod revision;
 pub mod trust;
 
-pub use self::review::Code as CodeReview;
-pub use self::review::Package as PackageReview;
+pub use self::review::{Code as CodeReview, Package as PackageReview};
 
 pub use self::{package_info::*, revision::*, trust::*};
 pub use crate::proof::content::{

--- a/crev-data/src/proof/review/code.rs
+++ b/crev-data/src/proof/review/code.rs
@@ -1,5 +1,4 @@
-use crate::{proof, Result};
-use crate::{serde_content_serialize, serde_draft_serialize};
+use crate::{proof, serde_content_serialize, serde_draft_serialize, Result};
 use crev_common::{
     self,
     serde::{as_base64, from_base64},

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -1,5 +1,4 @@
-use crate::{proof, Level, Result};
-use crate::{serde_content_serialize, serde_draft_serialize};
+use crate::{proof, serde_content_serialize, serde_draft_serialize, Level, Result};
 use crev_common::{self, is_equal_default, is_set_empty, is_vec_empty};
 use derive_builder::Builder;
 use failure::bail;
@@ -7,9 +6,7 @@ use proof::{CommonOps, Content};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_yaml;
-use std::collections::HashSet;
-use std::ops;
-use std::{default::Default, fmt};
+use std::{collections::HashSet, default::Default, fmt, ops};
 use typed_builder::TypedBuilder;
 
 const CURRENT_PACKAGE_REVIEW_PROOF_SERIALIZATION_VERSION: i64 = -1;

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -1,8 +1,7 @@
 use crate::{
     proof::{self, CommonOps, Content},
-    Level, Result,
+    serde_content_serialize, serde_draft_serialize, Level, Result,
 };
-use crate::{serde_content_serialize, serde_draft_serialize};
 use crev_common;
 use derive_builder::Builder;
 use failure::bail;

--- a/crev-lib/src/proofdb.rs
+++ b/crev-lib/src/proofdb.rs
@@ -15,8 +15,10 @@ use default::default;
 use failure::bail;
 use log::debug;
 use semver::Version;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::sync;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    sync,
+};
 
 /// A `T` with a timestamp
 ///


### PR DESCRIPTION
This allows users to use `cargo install cargo-crev` (without `--locked`).

Checklist:

* [x] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable
