### PR TITLE
fix: if owners fetch fails, treat as empty list

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Fixed
+
+* `crate verify` no longer hangs on unpublished local crates
+
 ## [0.14.0](https://github.com/dpc/crev/compare/cargo-crev-v0.13.0...cargo-crev-v0.14.0) - 2019-12-16
 ## Fixed
 

--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -286,7 +286,10 @@ impl Scanner {
             Err(_) => None,
         };
 
-        let owner_list = self.crates_io.get_owners(&pkg_name)?;
+        let owner_list = self
+            .crates_io
+            .get_owners(&pkg_name)
+            .unwrap_or_else(|_| vec![]);
         let total_owners_count = owner_list.len();
         let known_owners_count = owner_list
             .iter()


### PR DESCRIPTION
Fixes #272 

... though I should note that while this fixes the hang, the output is still weird (Windows):

```cmd
D:\repos\cad97\pointer-utils>cargo crev crate verify
status reviews     downloads    owner  issues lines  geiger flgs crate                version         latest_t
local   0  0        ?         ?
  0/0    0/0     355      49      erasable             1.0.0-dev*
local   0  0        ?         ?
  0/0    0/0     247       0      rc-borrow            1.0.0-dev*
```