### PR TITLE
Handle no known crates-io owners specifically

### DIFF
--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -160,7 +160,7 @@ pub struct CrateDetails {
     pub trusted_reviewers: HashSet<PubId>,
     pub version_reviews: CountWithTotal,
     pub version_downloads: Option<CountWithTotal>,
-    pub known_owners: CountWithTotal,
+    pub known_owners: Option<CountWithTotal>,
     pub dependencies: Vec<proof::PackageVersionId>,
     pub rev_dependencies: Vec<proof::PackageVersionId>,
     pub unclean_digest: bool,
@@ -311,7 +311,14 @@ pub fn verify_deps(crate_: CrateSelector, args: CrateVerify) -> Result<CommandEx
 
     let deps: Vec<_> = events
         .into_iter()
-        .filter(|stats| !args.skip_known_owners || stats.details.known_owners.count == 0)
+        .filter(|stats| {
+            !args.skip_known_owners
+                || stats
+                    .details
+                    .known_owners
+                    .map(|it| it.count == 0)
+                    .unwrap_or(false)
+        })
         .filter(|stats| !args.skip_verified || !stats.details.accumulative.verified)
         .map(|stats| {
             print_term::print_dep(&stats, &mut term, args.verbose, args.recursive)?;

--- a/cargo-crev/src/deps/print_term.rs
+++ b/cargo-crev/src/deps/print_term.rs
@@ -72,7 +72,7 @@ pub fn print_details(
             },
         )?;
     } else {
-        println!(" {:>8} {:>9}", "?", "?");
+        term.print(format_args!(" {:>8} {:>9}", "?", "?"), None)?;
     }
 
     if recursive_mode {
@@ -85,11 +85,19 @@ pub fn print_details(
             None,
         )?;
     } else {
-        term.print(
-            format_args!(" {:>2}", cdep.known_owners.count),
-            term::known_owners_count_color(cdep.known_owners.count),
-        )?;
-        term.print(format_args!("/{:<2}", cdep.known_owners.total), None)?;
+        if let Some(known_owners) = &cdep.known_owners {
+            term.print(
+                format_args!(" {:>2}", known_owners.count),
+                term::known_owners_count_color(known_owners.count),
+            )?;
+            term.print(format_args!("/{:<2}", known_owners.total), None)?;
+        } else {
+            term.print(
+                format_args!(" {:>2}", "?"),
+                term::known_owners_count_color(0),
+            )?;
+            term.print(format_args!("/{:<2}", "?"), None)?;
+        }
     }
 
     term.print(

--- a/cargo-crev/src/tui/verify_screen.rs
+++ b/cargo-crev/src/tui/verify_screen.rs
@@ -194,8 +194,12 @@ impl<'t> VerifyScreen<'t> {
                 2,
                 2,
                 Box::new(|dep: &CrateStats| {
-                    if dep.details().known_owners.count > 0 {
-                        ListViewCell::new(format!("{}", dep.details().known_owners.count), &TS.good)
+                    if let Some(known_owners) = &dep.details().known_owners {
+                        if known_owners.count > 0 {
+                            ListViewCell::new(format!("{}", known_owners.count), &TS.good)
+                        } else {
+                            ListViewCell::new("".to_owned(), &TS.std)
+                        }
                     } else {
                         ListViewCell::new("".to_owned(), &TS.std)
                     }
@@ -208,8 +212,12 @@ impl<'t> VerifyScreen<'t> {
                 3,
                 Box::new(|dep: &CrateStats| {
                     ListViewCell::new(
-                        if dep.details().known_owners.total > 0 {
-                            format!("{}", dep.details().known_owners.total)
+                        if let Some(known_owners) = &dep.details().known_owners {
+                            if known_owners.total > 0 {
+                                format!("{}", known_owners.total)
+                            } else {
+                                "".to_owned()
+                            }
                         } else {
                             "".to_owned()
                         },


### PR DESCRIPTION
New output:

```
D:\repos\cad97\this-is-not-published>cargo crev crate verify
status reviews     downloads    owner  issues lines  geiger flgs crate                version         latest_t
local   0  0        ?         ?  ?/?    0/0       3       0      this-is-not-published 0.1.0*
```

This also incidentally fixes the `println!` causing the broken line seen in #273.