### PR TITLE
Fix typo

### DIFF
--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -897,7 +897,7 @@ impl Local {
 
         eprintln!("");
         eprintln!("Your CrevID was created and will be printed below in an encrypted form.");
-        eprintln!("Make sure to back it up on another device, to prevent loosing it.");
+        eprintln!("Make sure to back it up on another device, to prevent losing it.");
 
         eprintln!("");
         println!("{}", locked);


### PR DESCRIPTION
lose = I no longer have then<br>loose = not tight

Common mistake, possibly even a typo. But it's something! :slightly_smiling_face: 