### PR TITLE
Tracking which URL<>Id mappings have been verified

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -164,7 +164,7 @@ fn print_ids<'a>(
             trust_set.get_effective_trust_level(id),
             match db.lookup_url(id) {
                 UrlOfId::None => "",
-                UrlOfId::FromSelf(url) => &url.url,
+                UrlOfId::FromSelfVerified(url) | UrlOfId::FromSelf(url) => &url.url,
                 UrlOfId::FromOthers(url) => {
                     tmp = format!("({})", url.url);
                     &tmp

--- a/crev-lib/src/tests/issues.rs
+++ b/crev-lib/src/tests/issues.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::local::FetchSource;
 use crev_data::{
     proof,
     review::{Advisory, Issue, VersionRange},
@@ -72,6 +73,7 @@ fn build_proof_with_issues(id: &OwnId, version: Version, issues: Vec<Issue>) -> 
 
 #[test]
 fn advisories_sanity() -> Result<()> {
+    let url = FetchSource::LocalUser;
     let id = OwnId::generate_for_git_url("https://a");
 
     let proof = build_proof_with_advisories(
@@ -81,7 +83,7 @@ fn advisories_sanity() -> Result<()> {
     );
 
     let mut proofdb = ProofDB::new();
-    proofdb.import_from_iter(vec![proof].into_iter());
+    proofdb.import_from_iter(vec![(proof, url.clone())].into_iter());
 
     assert_eq!(proofdb.get_pkg_reviews_for_source(SOURCE).count(), 1);
 
@@ -115,7 +117,7 @@ fn advisories_sanity() -> Result<()> {
         vec![build_advisory("someid", VersionRange::All)],
     );
 
-    proofdb.import_from_iter(vec![proof].into_iter());
+    proofdb.import_from_iter(vec![(proof, url)].into_iter());
 
     assert_eq!(
         proofdb
@@ -141,6 +143,7 @@ fn advisories_sanity() -> Result<()> {
 
 #[test]
 fn issues_sanity() -> Result<()> {
+    let url = FetchSource::LocalUser;
     let id = OwnId::generate_for_git_url("https://a");
     let mut trustdb = ProofDB::new();
     let trust_set = trustdb.calculate_trust_set(id.as_ref(), &TrustDistanceParams::new_no_wot());
@@ -150,7 +153,7 @@ fn issues_sanity() -> Result<()> {
         Version::parse("1.2.3").unwrap(),
         vec![build_advisory("issueX", VersionRange::Major)],
     );
-    trustdb.import_from_iter(vec![proof].into_iter());
+    trustdb.import_from_iter(vec![(proof, url.clone())].into_iter());
 
     assert_eq!(
         trustdb
@@ -183,7 +186,7 @@ fn issues_sanity() -> Result<()> {
         Version::parse("2.0.1").unwrap(),
         vec![build_advisory("issueY", VersionRange::All)],
     );
-    trustdb.import_from_iter(vec![proof].into_iter());
+    trustdb.import_from_iter(vec![(proof, url.clone())].into_iter());
     assert_eq!(
         trustdb
             .get_open_issues_for_version(
@@ -227,7 +230,7 @@ fn issues_sanity() -> Result<()> {
         Version::parse("3.0.5").unwrap(),
         vec![build_issue("issueX")],
     );
-    trustdb.import_from_iter(vec![proof].into_iter());
+    trustdb.import_from_iter(vec![(proof, url.clone())].into_iter());
 
     assert_eq!(
         trustdb
@@ -273,7 +276,7 @@ fn issues_sanity() -> Result<()> {
         Version::parse("3.1.0").unwrap(),
         vec![build_advisory("issueX", VersionRange::Major)],
     );
-    trustdb.import_from_iter(vec![proof].into_iter());
+    trustdb.import_from_iter(vec![(proof, url)].into_iter());
 
     assert_eq!(
         trustdb


### PR DESCRIPTION
#298

I think it'd be nice to save verified Id<=>Url mappings somewhere to disk, outside of the cache. Maybe even keep track of all fetched URLs as part of config, because it's weird that `crev repo fetch all` does nothing after a cache clear.

I'm using network for verification. Perhaps WoT could also be used, i.e. if a trust proof of person A I already trust contains a URL of person B, then consider that a valid URL for the person B even if it hasn't been fetched.
