### PR TITLE
Rename URL lookup fields and methods

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -161,7 +161,7 @@ fn print_ids<'a>(
             "{} {:6} {}",
             id,
             trust_set.get_effective_trust_level(id),
-            db.lookup_url(id).map(|url| url.url.as_str()).unwrap_or("")
+            db.lookup_unverified_url(id).map(|url| url.url.as_str()).unwrap_or("")
         );
     }
     Ok(())

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -543,7 +543,7 @@ impl Local {
         for id_string in id_strings {
             let id = Id::crevid_from_str(&id_string)?;
 
-            if let Some(url) = db.lookup_url(&id) {
+            if let Some(url) = db.lookup_unverified_url(&id) {
                 pub_ids.push(PubId::new(id, url.to_owned()));
             } else {
                 bail!(
@@ -606,7 +606,7 @@ impl Local {
                 }
                 already_fetched_ids.insert(id.to_owned());
 
-                if let Some(url) = db.lookup_url(id).cloned() {
+                if let Some(url) = db.lookup_unverified_url(id).cloned() {
                     let url = url.url;
                     if already_fetched_urls.contains(&url) {
                         continue;
@@ -639,7 +639,7 @@ impl Local {
                     continue;
                 }
                 already_fetched_ids.insert(id.to_owned());
-                if let Some(url) = db.lookup_url(id).cloned() {
+                if let Some(url) = db.lookup_unverified_url(id).cloned() {
                     let url = url.url;
 
                     if already_fetched_urls.contains(&url) {


### PR DESCRIPTION
This does not alter functionality in any way. It's just a rename.