### PR TITLE
Verify syntax of Ids

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -208,13 +208,25 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 }
             }
             opts::Id::Trust(args) => {
-                create_trust_proof(args.pub_ids, Trust, &args.common_proof_create)?;
+                create_trust_proof(
+                    ids_from_string(&args.pub_ids)?,
+                    Trust,
+                    &args.common_proof_create,
+                )?;
             }
             opts::Id::Untrust(args) => {
-                create_trust_proof(args.pub_ids, Untrust, &args.common_proof_create)?;
+                create_trust_proof(
+                    ids_from_string(&args.pub_ids)?,
+                    Untrust,
+                    &args.common_proof_create,
+                )?;
             }
             opts::Id::Distrust(args) => {
-                create_trust_proof(args.pub_ids, Distrust, &args.common_proof_create)?;
+                create_trust_proof(
+                    ids_from_string(&args.pub_ids)?,
+                    Distrust,
+                    &args.common_proof_create,
+                )?;
             }
             opts::Id::Query(cmd) => match cmd {
                 opts::IdQuery::Current { trust_params } => {
@@ -484,6 +496,16 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
     }
 
     Ok(CommandExitStatus::Success)
+}
+
+fn ids_from_string(id_strings: &[String]) -> Result<Vec<Id>> {
+    id_strings
+        .iter()
+        .map(|s| match Id::crevid_from_str(&s) {
+            Ok(s) => Ok(s),
+            Err(e) => bail!("'{}' is not a valid crev Id: {}", s, e),
+        })
+        .collect()
 }
 
 fn load_stdin_with_prompt() -> Result<Vec<u8>> {

--- a/crev-lib/src/id.rs
+++ b/crev-lib/src/id.rs
@@ -106,6 +106,7 @@ impl LockedId {
 
     pub fn to_pubid(&self) -> PubId {
         PubId::new_from_pubkey(self.public_key.to_owned(), self.url.clone())
+            .expect("own id should be valid")
     }
 
     pub fn pub_key_as_base64(&self) -> String {

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -531,25 +531,23 @@ impl Local {
     pub fn build_trust_proof(
         &self,
         from_id: &PubId,
-        id_strings: Vec<String>,
+        ids: Vec<Id>,
         trust_or_distrust: TrustProofType,
     ) -> Result<proof::trust::Trust> {
-        if id_strings.is_empty() {
+        if ids.is_empty() {
             bail!("No ids given.");
         }
 
         let db = self.load_db()?;
-        let mut pub_ids = vec![];
+        let mut pub_ids = Vec::with_capacity(ids.len());
 
-        for id_string in id_strings {
-            let id = Id::crevid_from_str(&id_string)?;
-
+        for id in ids {
             if let Some(url) = db.lookup_unverified_url(&id) {
                 pub_ids.push(PubId::new(id, url.to_owned()));
             } else {
                 bail!(
                     "URL not found for Id {}; Fetch proofs with `fetch url <url>` first",
-                    id_string
+                    id
                 )
             }
         }

--- a/crev-lib/src/proofdb.rs
+++ b/crev-lib/src/proofdb.rs
@@ -1153,7 +1153,7 @@ impl ProofDB {
 
     /// Can trust that this Id has reported the URL returned
     pub fn lookup_verified_url(&self, id: &Id) -> Option<&Url> {
-        self.url_by_id_self_reported.get(id)
+        self.url_by_id_self_reported.get(id).map(|url| &url.value)
     }
 }
 


### PR DESCRIPTION
Currently it's possible to "trust" anything that base64-decodes, even if it doesn't have the correct length. 

* [x] `cargo +nightly fmt --all`
