### PR TITLE
DRY

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -33,7 +33,7 @@ mod tui;
 use crate::{repo::*, review::*, shared::*};
 use crev_data::{proof, Id};
 use crev_lib::{
-    proofdb::{ProofDB, TrustSet},
+    proofdb::{ProofDB, TrustSet, UrlOfId},
     TrustProofType::{self, *},
 };
 
@@ -157,20 +157,19 @@ fn print_ids<'a>(
     db: &ProofDB,
 ) -> Result<()> {
     for id in ids {
-        let mut tmp = String::new();
+        let tmp;
         println!(
             "{} {:6} {}",
             id,
             trust_set.get_effective_trust_level(id),
-            db.lookup_verified_url(id)
-                .map(|url| url.url.as_str())
-                .or_else(|| {
-                    db.lookup_unverified_url(id).map(|url| {
-                        tmp = format!("({})", url.url);
-                        tmp.as_str()
-                    })
-                })
-                .unwrap_or("")
+            match db.lookup_url(id) {
+                UrlOfId::None => "",
+                UrlOfId::FromSelf(url) => &url.url,
+                UrlOfId::FromOthers(url) => {
+                    tmp = format!("({})", url.url);
+                    &tmp
+                }
+            },
         );
     }
     Ok(())

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -613,29 +613,10 @@ impl Local {
         let mut db = self.load_db()?;
         let for_id = self.get_for_id_from_str(for_id)?;
 
-        let mut something_was_fetched = true;
-        while something_was_fetched {
-            something_was_fetched = false;
+        loop {
             let trust_set = db.calculate_trust_set(&for_id, &trust_params);
-
-            for id in trust_set.trusted_ids() {
-                if already_fetched_ids.contains(id) {
-                    continue;
-                }
-                already_fetched_ids.insert(id.to_owned());
-
-                if let Some(url) = db.lookup_url(id).any_unverified() {
-                    let url = &url.url;
-                    if already_fetched_urls.contains(url) {
-                        continue;
-                    }
-                    already_fetched_urls.insert(url.clone());
-                    let url = url.clone();
-                    self.fetch_proof_repo_import_and_print_counts(&url, &mut db);
-                    something_was_fetched = true;
-                } else {
-                    eprintln!("No URL for {}", id);
-                }
+            if !self.fetch_ids_not_fetched_yet(trust_set.trusted_ids().cloned(), &mut already_fetched_ids, &mut already_fetched_urls, &mut db) {
+                break;
             }
         }
         Ok(())
@@ -648,31 +629,37 @@ impl Local {
     ) -> Result<()> {
         let mut already_fetched_ids = HashSet::new();
 
-        let mut something_was_fetched = true;
-        while something_was_fetched {
-            something_was_fetched = false;
-
-            for id in &db.all_known_ids() {
-                if already_fetched_ids.contains(id) {
-                    continue;
-                }
-                already_fetched_ids.insert(id.to_owned());
-                if let Some(url) = db.lookup_url(id).any_unverified() {
-                    let url = &url.url;
-
-                    if already_fetched_urls.contains(url) {
-                        continue;
-                    }
-                    already_fetched_urls.insert(url.clone());
-                    let url = url.clone();
-                    self.fetch_proof_repo_import_and_print_counts(&url, db);
-                    something_was_fetched = true;
-                } else {
-                    eprintln!("No URL for {}", id);
-                }
+        loop {
+            if !self.fetch_ids_not_fetched_yet(db.all_known_ids().into_iter(), &mut already_fetched_ids, &mut already_fetched_urls, db) {
+                break;
             }
         }
         Ok(())
+    }
+
+    /// True if something was fetched
+    fn fetch_ids_not_fetched_yet<'a>(&self, ids: impl Iterator<Item=Id>, already_fetched_ids: &mut HashSet<Id>, already_fetched_urls: &mut HashSet<String>, db: &mut ProofDB) -> bool {
+        let mut something_was_fetched = false;
+        for id in ids {
+            if already_fetched_ids.contains(&id) {
+                continue;
+            }
+            if let Some(url) = db.lookup_url(&id).any_unverified() {
+                let url = &url.url;
+
+                if already_fetched_urls.contains(url) {
+                    continue;
+                }
+                let url = url.clone();
+                self.fetch_proof_repo_import_and_print_counts(&url, db);
+                already_fetched_urls.insert(url);
+                something_was_fetched = true;
+            } else {
+                eprintln!("No URL for {}", id);
+            }
+            already_fetched_ids.insert(id);
+        }
+        something_was_fetched
     }
 
     pub fn get_remote_git_cache_path(&self, url: &str) -> Result<PathBuf> {

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -2,6 +2,7 @@ use crate::{
     activity::ReviewActivity,
     id::{self, LockedId, PassphraseFn},
     prelude::*,
+    proofdb::UrlOfId,
     util, ProofDB, ProofStore, TrustProofType,
 };
 use crev_common::{
@@ -542,16 +543,14 @@ impl Local {
         let mut pub_ids = Vec::with_capacity(ids.len());
 
         for id in ids {
-            let url = match db.lookup_verified_url(&id) {
-                Some(url) => Some(url),
-                None => match db.lookup_unverified_url(&id) {
-                    Some(maybe_url) => {
-                        let maybe_url = maybe_url.url.clone();
-                        self.fetch_url_into(&maybe_url, &mut db)?;
-                        db.lookup_verified_url(&id)
-                    }
-                    None => None,
-                },
+            let url = match db.lookup_url(&id) {
+                UrlOfId::FromSelf(url) => Some(url),
+                UrlOfId::FromOthers(maybe_url) => {
+                    let maybe_url = maybe_url.url.clone();
+                    self.fetch_url_into(&maybe_url, &mut db)?;
+                    db.lookup_url(&id).from_self()
+                }
+                UrlOfId::None => None,
             };
             if let Some(url) = url {
                 pub_ids.push(PubId::new(id, url.to_owned()));
@@ -590,7 +589,7 @@ impl Local {
             eprintln!("Found proofs from:");
             for (id, count) in db.all_author_ids() {
                 let tmp;
-                let verified_state = match db.lookup_verified_url(&id) {
+                let verified_state = match db.lookup_url(&id).from_self() {
                     Some(verified_url) if verified_url == &url => "verified owner",
                     Some(verified_url) => {
                         tmp = format!("copy from {}", verified_url.url);
@@ -625,13 +624,13 @@ impl Local {
                 }
                 already_fetched_ids.insert(id.to_owned());
 
-                if let Some(url) = db.lookup_unverified_url(id).cloned() {
-                    let url = url.url;
-                    if already_fetched_urls.contains(&url) {
+                if let Some(url) = db.lookup_url(id).any_unverified() {
+                    let url = &url.url;
+                    if already_fetched_urls.contains(url) {
                         continue;
                     }
                     already_fetched_urls.insert(url.clone());
-
+                    let url = url.clone();
                     self.fetch_proof_repo_import_and_print_counts(&url, &mut db);
                     something_was_fetched = true;
                 } else {
@@ -658,13 +657,14 @@ impl Local {
                     continue;
                 }
                 already_fetched_ids.insert(id.to_owned());
-                if let Some(url) = db.lookup_unverified_url(id).cloned() {
-                    let url = url.url;
+                if let Some(url) = db.lookup_url(id).any_unverified() {
+                    let url = &url.url;
 
-                    if already_fetched_urls.contains(&url) {
+                    if already_fetched_urls.contains(url) {
                         continue;
                     }
                     already_fetched_urls.insert(url.clone());
+                    let url = url.clone();
                     self.fetch_proof_repo_import_and_print_counts(&url, db);
                     something_was_fetched = true;
                 } else {


### PR DESCRIPTION
* Using enum to avoid looking up URL twice.
* Deduplicated body of fetch_trusted and fetch_all_ids_recursively