### PR TITLE
Clarify id structure names

### DIFF
--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -1,5 +1,5 @@
 use crate::to_fail;
-use crev_data::{proof, Digest, PubId};
+use crev_data::{proof, Digest, PublicId};
 use crev_lib::*;
 use semver::Version;
 use std::path::PathBuf;
@@ -175,7 +175,7 @@ impl std::ops::Add<AccumulativeCrateDetails> for AccumulativeCrateDetails {
 pub struct CrateDetails {
     pub digest: Option<Digest>,
     pub latest_trusted_version: Option<Version>,
-    pub trusted_reviewers: HashSet<PubId>,
+    pub trusted_reviewers: HashSet<PublicId>,
     pub version_reviews: CountWithTotal,
     pub downloads: Option<DownloadsStats>,
     pub known_owners: Option<CountWithTotal>,
@@ -298,7 +298,7 @@ pub fn crate_mvps(crate_: CrateSelector, common: CrateVerifyCommon) -> Result<()
     let scanner = scan::Scanner::new(crate_, &args)?;
     let events = scanner.run();
 
-    let mut mvps: HashMap<PubId, u64> = HashMap::new();
+    let mut mvps: HashMap<PublicId, u64> = HashMap::new();
 
     for stats in events {
         for reviewer in &stats.details.trusted_reviewers {

--- a/cargo-crev/src/dyn_proof.rs
+++ b/cargo-crev/src/dyn_proof.rs
@@ -1,7 +1,7 @@
 use common_failures::Result;
 use crev_data::{
     proof::{self, CommonOps, ContentExt},
-    OwnId, PubId,
+    PubId, UnlockedId,
 };
 use failure::bail;
 
@@ -17,7 +17,7 @@ pub fn parse_dyn_content(proof: &proof::Proof) -> Result<Box<dyn DynContent>> {
 pub trait DynContent {
     fn set_date(&mut self, date: &proof::Date);
     fn set_author(&mut self, id: &PubId);
-    fn sign_by(&self, id: &OwnId) -> Result<proof::Proof>;
+    fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof>;
 }
 
 impl DynContent for proof::review::Code {
@@ -27,7 +27,7 @@ impl DynContent for proof::review::Code {
     fn set_author(&mut self, id: &PubId) {
         self.common.from = id.clone();
     }
-    fn sign_by(&self, id: &OwnId) -> Result<proof::Proof> {
+    fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {
         Ok(ContentExt::sign_by(self, id)?)
     }
 }
@@ -38,7 +38,7 @@ impl DynContent for proof::review::Package {
     fn set_author(&mut self, id: &PubId) {
         self.common.from = id.clone();
     }
-    fn sign_by(&self, id: &OwnId) -> Result<proof::Proof> {
+    fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {
         Ok(ContentExt::sign_by(self, id)?)
     }
 }
@@ -49,7 +49,7 @@ impl DynContent for proof::trust::Trust {
     fn set_author(&mut self, id: &PubId) {
         self.common.from = id.clone();
     }
-    fn sign_by(&self, id: &OwnId) -> Result<proof::Proof> {
+    fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {
         Ok(ContentExt::sign_by(self, id)?)
     }
 }

--- a/cargo-crev/src/dyn_proof.rs
+++ b/cargo-crev/src/dyn_proof.rs
@@ -1,7 +1,7 @@
 use common_failures::Result;
 use crev_data::{
     proof::{self, CommonOps, ContentExt},
-    PubId, UnlockedId,
+    PublicId, UnlockedId,
 };
 use failure::bail;
 
@@ -16,7 +16,7 @@ pub fn parse_dyn_content(proof: &proof::Proof) -> Result<Box<dyn DynContent>> {
 
 pub trait DynContent {
     fn set_date(&mut self, date: &proof::Date);
-    fn set_author(&mut self, id: &PubId);
+    fn set_author(&mut self, id: &PublicId);
     fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof>;
 }
 
@@ -24,7 +24,7 @@ impl DynContent for proof::review::Code {
     fn set_date(&mut self, date: &proof::Date) {
         self.common.date = *date;
     }
-    fn set_author(&mut self, id: &PubId) {
+    fn set_author(&mut self, id: &PublicId) {
         self.common.from = id.clone();
     }
     fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {
@@ -35,7 +35,7 @@ impl DynContent for proof::review::Package {
     fn set_date(&mut self, date: &proof::Date) {
         self.common.date = *date;
     }
-    fn set_author(&mut self, id: &PubId) {
+    fn set_author(&mut self, id: &PublicId) {
         self.common.from = id.clone();
     }
     fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {
@@ -46,7 +46,7 @@ impl DynContent for proof::trust::Trust {
     fn set_date(&mut self, date: &proof::Date) {
         self.common.date = *date;
     }
-    fn set_author(&mut self, id: &PubId) {
+    fn set_author(&mut self, id: &PublicId) {
         self.common.from = id.clone();
     }
     fn sign_by(&self, id: &UnlockedId) -> Result<proof::Proof> {

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -283,7 +283,10 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                         let trust_set = db.calculate_trust_set(&id.id, &trust_params.into());
                         // local.list_own_ids()?
                         print_ids(
-                            local.list_ids()?.iter().map(|pub_id| &pub_id.id),
+                            local
+                                .get_current_user_public_ids()?
+                                .iter()
+                                .map(|pub_id| &pub_id.id),
                             &trust_set,
                             &db,
                         )?;

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -223,7 +223,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
             }
             opts::Id::Current => {
                 let local = Local::auto_open()?;
-                local.show_own_ids()?;
+                local.show_current_user_public_ids()?;
             }
             opts::Id::Export(args) => {
                 let local = Local::auto_open()?;
@@ -281,7 +281,6 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                         let id = id.to_pubid();
                         let db = local.load_db()?;
                         let trust_set = db.calculate_trust_set(&id.id, &trust_params.into());
-                        // local.list_own_ids()?
                         print_ids(
                             local
                                 .get_current_user_public_ids()?

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -248,21 +248,21 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
             }
             opts::Id::Trust(args) => {
                 create_trust_proof(
-                    ids_from_string(&args.pub_ids)?,
+                    ids_from_string(&args.public_ids)?,
                     Trust,
                     &args.common_proof_create,
                 )?;
             }
             opts::Id::Untrust(args) => {
                 create_trust_proof(
-                    ids_from_string(&args.pub_ids)?,
+                    ids_from_string(&args.public_ids)?,
                     Untrust,
                     &args.common_proof_create,
                 )?;
             }
             opts::Id::Distrust(args) => {
                 create_trust_proof(
-                    ids_from_string(&args.pub_ids)?,
+                    ids_from_string(&args.public_ids)?,
                     Distrust,
                     &args.common_proof_create,
                 )?;
@@ -271,7 +271,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 opts::IdQuery::Current { trust_params } => {
                     let local = Local::auto_open()?;
                     if let Some(id) = local.read_current_locked_id_opt()? {
-                        let id = id.to_pubid();
+                        let id = id.to_public_id();
                         let db = local.load_db()?;
                         let trust_set = db.calculate_trust_set(&id.id, &trust_params.into());
 
@@ -281,14 +281,14 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 opts::IdQuery::Own { trust_params } => {
                     let local = Local::auto_open()?;
                     if let Some(id) = local.read_current_locked_id_opt()? {
-                        let id = id.to_pubid();
+                        let id = id.to_public_id();
                         let db = local.load_db()?;
                         let trust_set = db.calculate_trust_set(&id.id, &trust_params.into());
                         print_ids(
                             local
                                 .get_current_user_public_ids()?
                                 .iter()
-                                .map(|pub_id| &pub_id.id),
+                                .map(|public_id| &public_id.id),
                             &trust_set,
                             &db,
                         )?;
@@ -343,7 +343,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
         },
         opts::Command::Trust(args) => {
             let (urls, ids): (Vec<_>, Vec<_>) = args
-                .pub_ids_or_urls
+                .public_ids_or_urls
                 .into_iter()
                 .partition(|arg| arg.starts_with("https://"));
             let mut ids = ids_from_string(&ids)?;
@@ -548,7 +548,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                             if args.reset_date {
                                 content.set_date(&now);
                             }
-                            content.set_author(&id.as_pubid());
+                            content.set_author(&id.as_public_id());
                             let proof = content.sign_by(&id)?;
                             maybe_store(&local, &proof, &commit_msg, &args.common)?;
                         }

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -237,7 +237,10 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 // the library
                 local.save_current_id(&id.id)?;
 
-                let url = &id.url.as_ref().expect("own Id must have a URL");
+                let url = &id
+                    .url
+                    .as_ref()
+                    .expect("A public id must have an associated URL");
                 let proof_dir_path = local.get_proofs_dir_path_for_url(url)?;
                 if !proof_dir_path.exists() {
                     local.clone_proof_dir_from_git(&url.url, false)?;

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -352,7 +352,7 @@ pub struct CrateVerify {
 #[derive(Debug, StructOpt, Clone)]
 pub struct IdTrust {
     /// Public IDs to create Trust Proof for
-    pub pub_ids: Vec<String>,
+    pub public_ids: Vec<String>,
 
     #[structopt(flatten)]
     pub common_proof_create: CommonProofCreate,
@@ -361,7 +361,7 @@ pub struct IdTrust {
 #[derive(Debug, StructOpt, Clone)]
 pub struct TrustUrls {
     /// Public IDs or proof repo URLs to create Trust Proof for
-    pub pub_ids_or_urls: Vec<String>,
+    pub public_ids_or_urls: Vec<String>,
 
     #[structopt(flatten)]
     pub common_proof_create: CommonProofCreate,

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -100,7 +100,7 @@ pub struct IdNew {
 
 #[derive(Debug, StructOpt, Clone)]
 pub struct IdSwitch {
-    /// Own Id to switch to
+    /// Id to switch to
     pub id: String,
 }
 

--- a/cargo-crev/src/repo.rs
+++ b/cargo-crev/src/repo.rs
@@ -1,12 +1,11 @@
 use crate::{opts, opts::CrateSelector, to_fail};
 use cargo::{
     core::{
-        resolver::features::RequestedFeatures,
         dependency::{DepKind, Dependency},
         manifest::ManifestMetadata,
         package::PackageSet,
         registry::PackageRegistry,
-        resolver::ResolveOpts,
+        resolver::{features::RequestedFeatures, ResolveOpts},
         source::SourceMap,
         InternedString, Package, PackageId, PackageIdSpec, Resolve, SourceId, Workspace,
     },

--- a/cargo-crev/src/review.rs
+++ b/cargo-crev/src/review.rs
@@ -154,7 +154,7 @@ pub fn create_review_proof(
 
 pub fn find_previous_review_data(
     db: &crev_wot::ProofDB,
-    id: &crev_data::PubId,
+    id: &crev_data::PublicId,
     name: &str,
     crate_version: &Version,
     diff_base_version: &Option<Version>,

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -618,16 +618,17 @@ pub fn create_trust_proof(
 ) -> Result<()> {
     let local = Local::auto_open()?;
 
-    let own_id = local.read_current_unlocked_id(&crev_common::read_passphrase)?;
+    let unlocked_id = local.read_current_unlocked_id(&crev_common::read_passphrase)?;
 
     let string_ids = ids
         .iter()
         .map(|id| id.to_string())
         .collect::<Vec<_>>()
         .join(", ");
-    let trust = local.build_trust_proof_interactively(own_id.as_pubid(), ids, trust_or_distrust)?;
+    let trust =
+        local.build_trust_proof_interactively(unlocked_id.as_pubid(), ids, trust_or_distrust)?;
 
-    let proof = trust.sign_by(&own_id)?;
+    let proof = trust.sign_by(&unlocked_id)?;
     let commit_msg = format!(
         "Add {t_or_d} for {ids}",
         t_or_d = trust_or_distrust,

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -625,8 +625,11 @@ pub fn create_trust_proof(
         .map(|id| id.to_string())
         .collect::<Vec<_>>()
         .join(", ");
-    let trust =
-        local.build_trust_proof_interactively(unlocked_id.as_pubid(), ids, trust_or_distrust)?;
+    let trust = local.build_trust_proof_interactively(
+        unlocked_id.as_public_id(),
+        ids,
+        trust_or_distrust,
+    )?;
 
     let proof = trust.sign_by(&unlocked_id)?;
     let commit_msg = format!(

--- a/crev-bin/src/opts.rs
+++ b/crev-bin/src/opts.rs
@@ -33,13 +33,13 @@ pub struct Remove {
 #[derive(Debug, StructOpt, Clone)]
 pub struct TrustAdd {
     /// Public IDs to create Trust Proof for
-    pub pub_ids: Vec<String>,
+    pub public_ids: Vec<String>,
 }
 
 #[derive(Debug, StructOpt, Clone)]
 pub struct TrustUrlAdd {
     /// Public IDs or proof repo URLs to create Trust Proof for
-    pub pub_ids_or_urls: Vec<String>,
+    pub public_ids_or_urls: Vec<String>,
 }
 
 #[derive(Debug, StructOpt, Clone)]

--- a/crev-data/src/id.rs
+++ b/crev-data/src/id.rs
@@ -162,24 +162,24 @@ impl PubId {
 
 /// A `PubId` with the corresponding secret key
 #[derive(Debug)]
-pub struct OwnId {
+pub struct UnlockedId {
     pub id: PubId,
     pub keypair: ed25519_dalek::Keypair,
 }
 
-impl AsRef<Id> for OwnId {
+impl AsRef<Id> for UnlockedId {
     fn as_ref(&self) -> &Id {
         &self.id.id
     }
 }
 
-impl AsRef<PubId> for OwnId {
+impl AsRef<PubId> for UnlockedId {
     fn as_ref(&self) -> &PubId {
         &self.id
     }
 }
 
-impl OwnId {
+impl UnlockedId {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(url: Url, sec_key: Vec<u8>) -> Result<Self> {
         let sec_key = SecretKey::from_bytes(&sec_key)?;
@@ -207,7 +207,7 @@ impl OwnId {
     }
 
     pub fn url(&self) -> &Url {
-        self.id.url.as_ref().expect("OwnId must have a URL")
+        self.id.url.as_ref().expect("UnlockedId must have a URL")
     }
 
     pub fn generate_for_git_url(url: &str) -> Self {

--- a/crev-data/src/lib.rs
+++ b/crev-data/src/lib.rs
@@ -16,7 +16,7 @@ pub use semver::Version;
 
 pub use crate::{
     digest::Digest,
-    id::{Id, PubId, UnlockedId},
+    id::{Id, PublicId, UnlockedId},
     level::Level,
     proof::{
         review,

--- a/crev-data/src/lib.rs
+++ b/crev-data/src/lib.rs
@@ -16,7 +16,7 @@ pub use semver::Version;
 
 pub use crate::{
     digest::Digest,
-    id::{Id, OwnId, PubId},
+    id::{Id, PubId, UnlockedId},
     level::Level,
     proof::{
         review,

--- a/crev-data/src/proof/content.rs
+++ b/crev-data/src/proof/content.rs
@@ -25,7 +25,7 @@ pub trait CommonOps {
             .expect("Common types are expected to always have the `kind` field backfilled")
     }
 
-    fn from(&self) -> &crate::PubId {
+    fn from(&self) -> &crate::PublicId {
         &self.common().from
     }
 
@@ -41,7 +41,7 @@ pub trait CommonOps {
         &self.common().from.id
     }
 
-    fn author_pub_id(&self) -> &crate::PubId {
+    fn author_public_id(&self) -> &crate::PublicId {
         &self.common().from
     }
 
@@ -68,7 +68,7 @@ pub struct Common {
     /// Timestamp of proof creation
     pub date: chrono::DateTime<FixedOffset>,
     /// Author of the proof
-    pub from: crate::PubId,
+    pub from: crate::PublicId,
 }
 
 impl CommonOps for Common {

--- a/crev-data/src/proof/content.rs
+++ b/crev-data/src/proof/content.rs
@@ -157,7 +157,7 @@ pub trait ContentExt: Content {
         Ok(body)
     }
 
-    fn sign_by(&self, id: &crate::id::OwnId) -> Result<Proof> {
+    fn sign_by(&self, id: &crate::id::UnlockedId) -> Result<Proof> {
         let body = self.serialize()?;
         let signature = id.sign(&body.as_bytes());
         Ok(Proof {

--- a/crev-data/src/proof/review/code.rs
+++ b/crev-data/src/proof/review/code.rs
@@ -55,7 +55,7 @@ impl Code {
 }
 
 impl CodeBuilder {
-    pub fn from<VALUE: Into<crate::PubId>>(&mut self, value: VALUE) -> &mut Self {
+    pub fn from<VALUE: Into<crate::PublicId>>(&mut self, value: VALUE) -> &mut Self {
         if let Some(ref mut common) = self.common {
             common.from = value.into();
         } else {

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -86,7 +86,7 @@ pub struct Package {
 }
 
 impl PackageBuilder {
-    pub fn from<VALUE: Into<crate::PubId>>(&mut self, value: VALUE) -> &mut Self {
+    pub fn from<VALUE: Into<crate::PublicId>>(&mut self, value: VALUE) -> &mut Self {
         if let Some(ref mut common) = self.common {
             common.from = value.into();
         } else {

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -74,7 +74,7 @@ impl TrustLevel {
 pub struct Trust {
     #[serde(flatten)]
     pub common: proof::Common,
-    pub ids: Vec<crate::PubId>,
+    pub ids: Vec<crate::PublicId>,
     #[builder(default = "Default::default()")]
     pub trust: TrustLevel,
     #[serde(skip_serializing_if = "String::is_empty", default = "Default::default")]
@@ -83,7 +83,7 @@ pub struct Trust {
 }
 
 impl TrustBuilder {
-    pub fn from<VALUE: Into<crate::PubId>>(&mut self, value: VALUE) -> &mut Self {
+    pub fn from<VALUE: Into<crate::PublicId>>(&mut self, value: VALUE) -> &mut Self {
         if let Some(ref mut common) = self.common {
             common.from = value.into();
         } else {

--- a/crev-data/src/tests.rs
+++ b/crev-data/src/tests.rs
@@ -234,7 +234,7 @@ pub fn ensure_serializes_to_valid_proof_works() -> Result<()> {
     };
 
     let mut package =
-        a.as_pubid()
+        a.as_public_id()
             .create_package_review_proof(package, Default::default(), "a".into())?;
     assert!(package.ensure_serializes_to_valid_proof().is_ok());
     package.comment = std::iter::repeat("a").take(32_000).collect::<String>();

--- a/crev-data/src/tests.rs
+++ b/crev-data/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    id::OwnId,
+    id::UnlockedId,
     proof::{self, ContentExt, Proof},
     Result, Url,
 };
@@ -158,8 +158,8 @@ review:
     Ok(())
 }
 
-pub fn generate_id_and_proof() -> Result<(OwnId, Proof)> {
-    let id = OwnId::generate(Url::new_git("https://mypage.com/trust.git"));
+pub fn generate_id_and_proof() -> Result<(UnlockedId, Proof)> {
+    let id = UnlockedId::generate(Url::new_git("https://mypage.com/trust.git"));
 
     let package_info = proof::PackageInfo {
         id: proof::PackageVersionId::new(
@@ -219,7 +219,7 @@ pub fn verify_works() -> Result<()> {
 
 #[test]
 pub fn ensure_serializes_to_valid_proof_works() -> Result<()> {
-    let a = OwnId::generate_for_git_url("https://a");
+    let a = UnlockedId::generate_for_git_url("https://a");
     let digest = vec![0; 32];
     let package = proof::PackageInfo {
         id: proof::PackageVersionId::new(

--- a/crev-lib/src/id.rs
+++ b/crev-lib/src/id.rs
@@ -4,7 +4,7 @@ use crev_common::{
     rand::random_vec,
     serde::{as_base64, from_base64},
 };
-use crev_data::id::{PubId, UnlockedId};
+use crev_data::id::{PublicId, UnlockedId};
 use failure::{bail, format_err};
 
 use serde::{Deserialize, Serialize};
@@ -104,8 +104,8 @@ impl LockedId {
     }
 
     /// Extract only the public identity part from all data
-    pub fn to_pubid(&self) -> PubId {
-        PubId::new_from_pubkey(self.public_key.to_owned(), self.url.clone())
+    pub fn to_public_id(&self) -> PublicId {
+        PublicId::new_from_pubkey(self.public_key.to_owned(), self.url.clone())
             .expect("Invalid locked id.")
     }
 

--- a/crev-lib/src/id.rs
+++ b/crev-lib/src/id.rs
@@ -4,7 +4,7 @@ use crev_common::{
     rand::random_vec,
     serde::{as_base64, from_base64},
 };
-use crev_data::id::{OwnId, PubId};
+use crev_data::id::{PubId, UnlockedId};
 use failure::{bail, format_err};
 
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,7 @@ impl std::str::FromStr for LockedId {
 }
 
 impl LockedId {
-    pub fn from_own_id(own_id: &OwnId, passphrase: &str) -> Result<LockedId> {
+    pub fn from_unlocked_id(unlocked_id: &UnlockedId, passphrase: &str) -> Result<LockedId> {
         use miscreant::aead::Aead;
 
         let config = Config {
@@ -88,10 +88,10 @@ impl LockedId {
 
         Ok(LockedId {
             version: CURRENT_LOCKED_ID_SERIALIZATION_VERSION,
-            public_key: own_id.keypair.public.to_bytes().to_vec(),
-            sealed_secret_key: siv.seal(&seal_nonce, &[], own_id.keypair.secret.as_bytes()),
+            public_key: unlocked_id.keypair.public.to_bytes().to_vec(),
+            sealed_secret_key: siv.seal(&seal_nonce, &[], unlocked_id.keypair.secret.as_bytes()),
             seal_nonce,
-            url: own_id.url().clone(),
+            url: unlocked_id.url().clone(),
             pass: PassConfig {
                 salt: pwsalt,
                 iterations: config.time_cost,
@@ -106,7 +106,7 @@ impl LockedId {
     /// Extract only the public identity part from all data
     pub fn to_pubid(&self) -> PubId {
         PubId::new_from_pubkey(self.public_key.to_owned(), self.url.clone())
-            .expect("own id should be valid")
+            .expect("Invalid locked id.")
     }
 
     pub fn pub_key_as_base64(&self) -> String {
@@ -135,7 +135,7 @@ impl LockedId {
         Ok(serde_yaml::from_reader(&file)?)
     }
 
-    pub fn to_unlocked(&self, passphrase: &str) -> Result<OwnId> {
+    pub fn to_unlocked(&self, passphrase: &str) -> Result<UnlockedId> {
         let LockedId {
             ref version,
             ref url,
@@ -183,7 +183,7 @@ impl LockedId {
 
             assert!(!secret_key.is_empty());
 
-            let result = OwnId::new(url.to_owned(), secret_key)?;
+            let result = UnlockedId::new(url.to_owned(), secret_key)?;
             if public_key != &result.keypair.public.to_bytes() {
                 bail!("PubKey mismatch");
             }

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -261,8 +261,8 @@ impl Local {
         }
     }
 
-    /// Ids that belong to the user, nothing else
-    pub fn list_ids(&self) -> Result<Vec<PubId>> {
+    /// Returns public Ids which belong to the current user.
+    pub fn get_current_user_public_ids(&self) -> Result<Vec<PubId>> {
         let ids_path = self.user_ids_path();
         let mut ids = vec![];
         for dir_entry in std::fs::read_dir(&ids_path)? {
@@ -1012,10 +1012,10 @@ impl Local {
         self.show_own_ids()
     }
 
-    /// Print Ids. See `list_ids()`
+    /// Print Ids. See `get_current_user_public_ids()`
     pub fn show_own_ids(&self) -> Result<()> {
         let current = self.read_current_locked_id_opt()?.map(|id| id.to_pubid());
-        for id in self.list_ids()? {
+        for id in self.get_current_user_public_ids()? {
             let is_current = current.as_ref().map_or(false, |c| c.id == id.id);
             println!(
                 "{} {}{}",

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -1009,11 +1009,11 @@ impl Local {
 
     #[deprecated]
     pub fn list_own_ids(&self) -> Result<()> {
-        self.show_own_ids()
+        self.show_current_user_public_ids()
     }
 
-    /// Print Ids. See `get_current_user_public_ids()`
-    pub fn show_own_ids(&self) -> Result<()> {
+    /// Print the current user's public Ids.
+    pub fn show_current_user_public_ids(&self) -> Result<()> {
         let current = self.read_current_locked_id_opt()?.map(|id| id.to_pubid());
         for id in self.get_current_user_public_ids()? {
             let is_current = current.as_ref().map_or(false, |c| c.id == id.id);

--- a/crev-lib/src/tests.rs
+++ b/crev-lib/src/tests.rs
@@ -59,7 +59,7 @@ pass:
     let unlocked = locked.to_unlocked("a")?;
 
     let _trust_proof =
-        unlocked.create_signed_trust_proof(vec![unlocked.as_pubid()], TrustLevel::High)?;
+        unlocked.create_signed_trust_proof(vec![unlocked.as_public_id()], TrustLevel::High)?;
 
     Ok(())
 }
@@ -116,10 +116,10 @@ fn proofdb_distance() -> Result<()> {
         max_distance: 111,
     };
 
-    let a_to_b = a.create_signed_trust_proof(vec![b.as_pubid()], TrustLevel::High)?;
-    let b_to_c = b.create_signed_trust_proof(vec![c.as_pubid()], TrustLevel::Medium)?;
-    let c_to_d = c.create_signed_trust_proof(vec![d.as_pubid()], TrustLevel::Low)?;
-    let d_to_e = d.create_signed_trust_proof(vec![e.as_pubid()], TrustLevel::High)?;
+    let a_to_b = a.create_signed_trust_proof(vec![b.as_public_id()], TrustLevel::High)?;
+    let b_to_c = b.create_signed_trust_proof(vec![c.as_public_id()], TrustLevel::Medium)?;
+    let c_to_d = c.create_signed_trust_proof(vec![d.as_public_id()], TrustLevel::Low)?;
+    let d_to_e = d.create_signed_trust_proof(vec![e.as_public_id()], TrustLevel::High)?;
 
     let mut trustdb = ProofDB::new();
 
@@ -141,7 +141,7 @@ fn proofdb_distance() -> Result<()> {
     assert!(trust_set.contains(d.as_ref()));
     assert!(!trust_set.contains(e.as_ref()));
 
-    let b_to_d = b.create_signed_trust_proof(vec![d.as_pubid()], TrustLevel::Medium)?;
+    let b_to_d = b.create_signed_trust_proof(vec![d.as_public_id()], TrustLevel::Medium)?;
 
     trustdb.import_from_iter(vec![(b_to_d, url)].into_iter());
 
@@ -181,7 +181,7 @@ fn overwritting_reviews() -> Result<()> {
     };
 
     let proof1 = a
-        .as_pubid()
+        .as_public_id()
         .create_package_review_proof(package.clone(), default(), "a".into())?
         .sign_by(&a)?;
     // it's lame, but oh well... ; we need to make sure there's a time delay between
@@ -189,7 +189,7 @@ fn overwritting_reviews() -> Result<()> {
     #[allow(deprecated)]
     std::thread::sleep_ms(1);
     let proof2 = a
-        .as_pubid()
+        .as_public_id()
         .create_package_review_proof(package.clone(), default(), "b".into())?
         .sign_by(&a)?;
 
@@ -254,7 +254,7 @@ fn dont_consider_an_empty_review_as_valid() -> Result<()> {
     let review = crev_data::proof::review::Review::new_none();
 
     let proof1 = a
-        .as_pubid()
+        .as_public_id()
         .create_package_review_proof(package, review, "a".into())?
         .sign_by(&a)?;
 
@@ -295,10 +295,10 @@ fn proofdb_distrust() -> Result<()> {
     };
 
     let a_to_bc =
-        a.create_signed_trust_proof(vec![b.as_pubid(), c.as_pubid()], TrustLevel::High)?;
-    let b_to_d = b.create_signed_trust_proof(vec![d.as_pubid()], TrustLevel::Low)?;
-    let d_to_c = d.create_signed_trust_proof(vec![c.as_pubid()], TrustLevel::Distrust)?;
-    let c_to_e = c.create_signed_trust_proof(vec![e.as_pubid()], TrustLevel::High)?;
+        a.create_signed_trust_proof(vec![b.as_public_id(), c.as_public_id()], TrustLevel::High)?;
+    let b_to_d = b.create_signed_trust_proof(vec![d.as_public_id()], TrustLevel::Low)?;
+    let d_to_c = d.create_signed_trust_proof(vec![c.as_public_id()], TrustLevel::Distrust)?;
+    let c_to_e = c.create_signed_trust_proof(vec![e.as_public_id()], TrustLevel::High)?;
 
     let mut trustdb = ProofDB::new();
 
@@ -320,7 +320,7 @@ fn proofdb_distrust() -> Result<()> {
     assert!(trust_set.contains(d.as_ref()));
     assert!(!trust_set.contains(e.as_ref()));
 
-    let e_to_d = e.create_signed_trust_proof(vec![d.as_pubid()], TrustLevel::Distrust)?;
+    let e_to_d = e.create_signed_trust_proof(vec![d.as_public_id()], TrustLevel::Distrust)?;
 
     trustdb.import_from_iter(vec![(e_to_d, url)].into_iter());
 

--- a/crev-lib/src/tests.rs
+++ b/crev-lib/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crev_data::{
     proof::{self, trust::TrustLevel, ContentExt},
-    Digest, Level, OwnId, Url,
+    Digest, Level, UnlockedId, Url,
 };
 use crev_wot::{FetchSource, ProofDB};
 use default::default;
@@ -18,17 +18,17 @@ mod issues;
 // * compare
 #[test]
 fn lock_and_unlock() -> Result<()> {
-    let id = OwnId::generate_for_git_url("https://example.com/crev-proofs");
+    let id = UnlockedId::generate_for_git_url("https://example.com/crev-proofs");
 
-    let id_relocked = id::LockedId::from_own_id(&id, "password")?.to_unlocked("password")?;
+    let id_relocked = id::LockedId::from_unlocked_id(&id, "password")?.to_unlocked("password")?;
     assert_eq!(id.id.id, id_relocked.id.id);
 
-    assert!(id::LockedId::from_own_id(&id, "password")?
+    assert!(id::LockedId::from_unlocked_id(&id, "password")?
         .to_unlocked("wrongpassword")
         .is_err());
 
-    let id_stored = serde_yaml::to_string(&id::LockedId::from_own_id(&id, "pass")?)?;
-    let id_restored: OwnId =
+    let id_stored = serde_yaml::to_string(&id::LockedId::from_unlocked_id(&id, "pass")?)?;
+    let id_restored: UnlockedId =
         serde_yaml::from_str::<id::LockedId>(&id_stored)?.to_unlocked("pass")?;
 
     println!("{}", id_stored);
@@ -103,11 +103,11 @@ NtGu3z1Jtnj6wx8INBrVujcOPz61BiGmJS-UoAOe0XQutatFsEbgAcAo7rBvZz4Q-ccNXIFZtKnXhBDM
 fn proofdb_distance() -> Result<()> {
     let url = FetchSource::Url(Arc::new(Url::new_git("https://example.com")));
 
-    let a = OwnId::generate_for_git_url("https://a");
-    let b = OwnId::generate_for_git_url("https://b");
-    let c = OwnId::generate_for_git_url("https://c");
-    let d = OwnId::generate_for_git_url("https://d");
-    let e = OwnId::generate_for_git_url("https://e");
+    let a = UnlockedId::generate_for_git_url("https://a");
+    let b = UnlockedId::generate_for_git_url("https://b");
+    let c = UnlockedId::generate_for_git_url("https://c");
+    let d = UnlockedId::generate_for_git_url("https://d");
+    let e = UnlockedId::generate_for_git_url("https://e");
 
     let distance_params = TrustDistanceParams {
         high_trust_distance: 1,
@@ -166,7 +166,7 @@ fn proofdb_distance() -> Result<()> {
 #[test]
 fn overwritting_reviews() -> Result<()> {
     let url = FetchSource::Url(Arc::new(Url::new_git("https://a")));
-    let a = OwnId::generate_for_git_url("https://a");
+    let a = UnlockedId::generate_for_git_url("https://a");
     let digest = vec![0; 32];
     let package = crev_data::proof::PackageInfo {
         id: proof::PackageVersionId::new(
@@ -237,7 +237,7 @@ fn overwritting_reviews() -> Result<()> {
 #[test]
 fn dont_consider_an_empty_review_as_valid() -> Result<()> {
     let url = FetchSource::Url(Arc::new(Url::new_git("https://a")));
-    let a = OwnId::generate_for_git_url("https://a");
+    let a = UnlockedId::generate_for_git_url("https://a");
     let digest = vec![0; 32];
     let package = crev_data::proof::PackageInfo {
         id: proof::PackageVersionId::new(
@@ -281,11 +281,11 @@ fn dont_consider_an_empty_review_as_valid() -> Result<()> {
 #[test]
 fn proofdb_distrust() -> Result<()> {
     let url = FetchSource::Url(Arc::new(Url::new_git("https://a")));
-    let a = OwnId::generate_for_git_url("https://a");
-    let b = OwnId::generate_for_git_url("https://b");
-    let c = OwnId::generate_for_git_url("https://c");
-    let d = OwnId::generate_for_git_url("https://d");
-    let e = OwnId::generate_for_git_url("https://e");
+    let a = UnlockedId::generate_for_git_url("https://a");
+    let b = UnlockedId::generate_for_git_url("https://b");
+    let c = UnlockedId::generate_for_git_url("https://c");
+    let d = UnlockedId::generate_for_git_url("https://d");
+    let e = UnlockedId::generate_for_git_url("https://e");
 
     let distance_params = TrustDistanceParams {
         high_trust_distance: 1,

--- a/crev-lib/src/tests/issues.rs
+++ b/crev-lib/src/tests/issues.rs
@@ -3,7 +3,7 @@ use super::*;
 use crev_data::{
     proof,
     review::{Advisory, Issue, VersionRange},
-    OwnId, TrustLevel,
+    TrustLevel, UnlockedId,
 };
 use crev_wot::FetchSource;
 use ifmt::iformat;
@@ -30,7 +30,7 @@ fn build_issue(id: impl Into<String>) -> Issue {
 }
 
 fn build_proof_with_advisories(
-    id: &OwnId,
+    id: &UnlockedId,
     version: Version,
     advisories: Vec<Advisory>,
 ) -> proof::Proof {
@@ -52,7 +52,7 @@ fn build_proof_with_advisories(
     review.sign_by(&id).unwrap()
 }
 
-fn build_proof_with_issues(id: &OwnId, version: Version, issues: Vec<Issue>) -> proof::Proof {
+fn build_proof_with_issues(id: &UnlockedId, version: Version, issues: Vec<Issue>) -> proof::Proof {
     let package_info = proof::PackageInfo {
         id: proof::PackageVersionId::new("SOURCE_ID".to_owned(), NAME.into(), version),
         digest: vec![0, 1, 2, 3],
@@ -74,7 +74,7 @@ fn build_proof_with_issues(id: &OwnId, version: Version, issues: Vec<Issue>) -> 
 #[test]
 fn advisories_sanity() -> Result<()> {
     let url = FetchSource::LocalUser;
-    let id = OwnId::generate_for_git_url("https://a");
+    let id = UnlockedId::generate_for_git_url("https://a");
 
     let proof = build_proof_with_advisories(
         &id,
@@ -144,7 +144,7 @@ fn advisories_sanity() -> Result<()> {
 #[test]
 fn issues_sanity() -> Result<()> {
     let url = FetchSource::LocalUser;
-    let id = OwnId::generate_for_git_url("https://a");
+    let id = UnlockedId::generate_for_git_url("https://a");
     let mut trustdb = ProofDB::new();
     let trust_set = trustdb.calculate_trust_set(id.as_ref(), &TrustDistanceParams::new_no_wot());
 

--- a/crev-wot/src/lib.rs
+++ b/crev-wot/src/lib.rs
@@ -911,8 +911,8 @@ impl ProofDB {
             })
     }
 
-    /// Record an untrusted mapping between a PubId and a URL it declares
-    fn record_url_from_to_field(&mut self, date: &DateTime<Utc>, to: &crev_data::PubId) {
+    /// Record an untrusted mapping between a PublicId and a URL it declares
+    fn record_url_from_to_field(&mut self, date: &DateTime<Utc>, to: &crev_data::PublicId) {
         if let Some(url) = &to.url {
             self.url_by_id_reported_by_others
                 .entry(to.id.clone())
@@ -923,11 +923,11 @@ impl ProofDB {
         }
     }
 
-    /// Record mapping between a PubId and a URL it declares, and trust it's correct only if it's been fetched from the same URL
+    /// Record mapping between a PublicId and a URL it declares, and trust it's correct only if it's been fetched from the same URL
     fn record_url_from_from_field(
         &mut self,
         date: &DateTime<Utc>,
-        from: &crev_data::PubId,
+        from: &crev_data::PublicId,
         fetched_from: &FetchSource,
     ) {
         if let Some(url) = &from.url {


### PR DESCRIPTION
Rename `OwnId` to `UnlockedId`.

Rename `PubId` to `PublicId`.

Rename function `Local.show_own_ids()` to `Local.show_current_user_public_ids()`.

Rename function `Local.list_ids()` to `Local.get_current_user_public_ids()`.