### PR TITLE
Move functionality for printing current ID from crev-lib to cargo-crev.

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -224,7 +224,18 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
             }
             opts::Id::Current => {
                 let local = Local::auto_open()?;
-                local.show_current_user_public_ids()?;
+                let current = local
+                    .read_current_locked_id_opt()?
+                    .map(|id| id.to_public_id());
+                for id in local.get_current_user_public_ids()? {
+                    let is_current = current.as_ref().map_or(false, |c| c.id == id.id);
+                    println!(
+                        "{} {}{}",
+                        id.id,
+                        id.url_display(),
+                        if is_current { " (current)" } else { "" }
+                    );
+                }
             }
             opts::Id::Export(args) => {
                 let local = Local::auto_open()?;

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -1011,23 +1011,6 @@ impl Local {
         Ok(())
     }
 
-    /// Print the current user's public Ids.
-    pub fn show_current_user_public_ids(&self) -> Result<()> {
-        let current = self
-            .read_current_locked_id_opt()?
-            .map(|id| id.to_public_id());
-        for id in self.get_current_user_public_ids()? {
-            let is_current = current.as_ref().map_or(false, |c| c.id == id.id);
-            println!(
-                "{} {}{}",
-                id.id,
-                id.url_display(),
-                if is_current { " (current)" } else { "" }
-            );
-        }
-        Ok(())
-    }
-
     /// See `read_locked_id`
     pub fn export_locked_id(&self, id_str: Option<String>) -> Result<String> {
         let id = if let Some(id_str) = id_str {


### PR DESCRIPTION
Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
