### PR TITLE
Add config file for optional pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# See https://pre-commit.com/ for usage and config
+repos:
+- repo: local
+  hooks:
+  - id: fmt
+    name: cargo fmt
+    description: Format files with cargo fmt.
+    entry: cargo fmt --
+    language: system
+    types: [rust]
+    stages: [commit]
+    args: []
+
+  - id: test
+    name: cargo test
+    description: Run tests with cargo test.
+    entry: cargo test
+    language: system
+    types: [rust]
+    stages: [push]
+    args: []

--- a/HACKING.md
+++ b/HACKING.md
@@ -17,6 +17,19 @@
 
 For core crates, the rule is that any given crate can only depend on the lower layer.
 
+## Continuous Integration
+
+To streamline development, this repository uses continuous integration (CI) to check that tests pass and that the code is correctly formatted.
+
+These checks can be automatically executed locally using [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). They will be executed before running Git commands (such as commit). Git hooks for this repository can be trivially installed using the [pre-commit](https://pre-commit.com/) Python package:
+
+```shell
+pip install pre-commit
+pre-commit install -t pre-commit -t pre-push
+```
+
+Hooks for this project are defined in `./.pre-commit-config.yaml`. Pre-commit allows a developer to chose which hooks to install.
+
 ## Misc
 
 Other than that there's not that much structure yet, and everything is still fluid

--- a/crev-lib/src/util/mod.rs
+++ b/crev-lib/src/util/mod.rs
@@ -1,5 +1,4 @@
-pub use crev_common::{run_with_shell_cmd, store_str_to_file, store_to_file_with,
-};
+pub use crev_common::{run_with_shell_cmd, store_str_to_file, store_to_file_with};
 use crev_data::proof;
 use std::{
     self, io,


### PR DESCRIPTION
Runs `cargo fmt` before forming a commit. See https://pre-commit.com/ for usage.
