### PR TITLE
Separate ID trust proof creation from storage.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
   - id: test
     name: cargo test
     description: Run tests with cargo test.
-    entry: cargo test
-    language: system
+    entry: cargo test --
+    language: rust
     types: [rust]
     stages: [push]
     args: []

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -259,25 +259,64 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 }
             }
             opts::Id::Trust(args) => {
-                create_trust_proof(
-                    ids_from_string(&args.public_ids)?,
-                    Trust,
-                    &args.common_proof_create,
-                )?;
+                let ids = ids_from_string(&args.public_ids)?;
+                let id_trust_proof_type = Trust;
+                let proof = create_id_trust_proof_interactively(&ids, id_trust_proof_type)?;
+
+                if args.common_proof_create.print_unsigned {
+                    print!("{}", proof.body());
+                }
+                if args.common_proof_create.print_signed {
+                    print!("{}", proof);
+                }
+                if !args.common_proof_create.no_store {
+                    crev_lib::proof::store_id_trust_proof(
+                        &proof,
+                        &ids,
+                        id_trust_proof_type,
+                        !args.common_proof_create.no_commit,
+                    )?;
+                }
             }
             opts::Id::Untrust(args) => {
-                create_trust_proof(
-                    ids_from_string(&args.public_ids)?,
-                    Untrust,
-                    &args.common_proof_create,
-                )?;
+                let ids = ids_from_string(&args.public_ids)?;
+                let id_trust_proof_type = Untrust;
+                let proof = create_id_trust_proof_interactively(&ids, id_trust_proof_type)?;
+
+                if args.common_proof_create.print_unsigned {
+                    print!("{}", proof.body());
+                }
+                if args.common_proof_create.print_signed {
+                    print!("{}", proof);
+                }
+                if !args.common_proof_create.no_store {
+                    crev_lib::proof::store_id_trust_proof(
+                        &proof,
+                        &ids,
+                        id_trust_proof_type,
+                        !args.common_proof_create.no_commit,
+                    )?;
+                }
             }
             opts::Id::Distrust(args) => {
-                create_trust_proof(
-                    ids_from_string(&args.public_ids)?,
-                    Distrust,
-                    &args.common_proof_create,
-                )?;
+                let ids = ids_from_string(&args.public_ids)?;
+                let id_trust_proof_type = Distrust;
+                let proof = create_id_trust_proof_interactively(&ids, id_trust_proof_type)?;
+
+                if args.common_proof_create.print_unsigned {
+                    print!("{}", proof.body());
+                }
+                if args.common_proof_create.print_signed {
+                    print!("{}", proof);
+                }
+                if !args.common_proof_create.no_store {
+                    crev_lib::proof::store_id_trust_proof(
+                        &proof,
+                        &ids,
+                        id_trust_proof_type,
+                        !args.common_proof_create.no_commit,
+                    )?;
+                }
             }
             opts::Id::Query(cmd) => match cmd {
                 opts::IdQuery::Current { trust_params } => {
@@ -387,7 +426,23 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                     eprintln!("warning: Could not find Id for URL {}", url);
                 }
             }
-            create_trust_proof(ids, Trust, &args.common_proof_create)?;
+            let id_trust_proof_type = Trust;
+            let proof = create_id_trust_proof_interactively(&ids, id_trust_proof_type)?;
+
+            if args.common_proof_create.print_unsigned {
+                print!("{}", proof.body());
+            }
+            if args.common_proof_create.print_signed {
+                print!("{}", proof);
+            }
+            if !args.common_proof_create.no_store {
+                crev_lib::proof::store_id_trust_proof(
+                    &proof,
+                    &ids,
+                    id_trust_proof_type,
+                    !args.common_proof_create.no_commit,
+                )?;
+            }
         }
         opts::Command::Crate(args) => match args {
             opts::Crate::Diff(args) => {

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -611,38 +611,20 @@ where
     Ok(())
 }
 
-/// Creates new trust proof interactively
-pub fn create_trust_proof(
-    ids: Vec<Id>,
+/// Creates a new trust proof interactively
+pub fn create_id_trust_proof_interactively(
+    ids: &[Id],
     trust_or_distrust: TrustProofType,
-    proof_create_opt: &opts::CommonProofCreate,
-) -> Result<()> {
+) -> Result<proof::Proof> {
     let local = Local::auto_open()?;
-
     let unlocked_id = local.read_current_unlocked_id(&crev_common::read_passphrase)?;
-
-    let string_ids = ids
-        .iter()
-        .map(|id| id.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
     let trust = edit::build_trust_proof_interactively(
         &local,
         unlocked_id.as_public_id(),
-        ids,
+        ids.to_vec(),
         trust_or_distrust,
     )?;
-
-    let proof = trust.sign_by(&unlocked_id)?;
-    let commit_msg = format!(
-        "Add {t_or_d} for {ids}",
-        t_or_d = trust_or_distrust,
-        ids = string_ids
-    );
-
-    maybe_store(&local, &proof, &commit_msg, proof_create_opt)?;
-
-    Ok(())
+    Ok(trust.sign_by(&unlocked_id)?)
 }
 
 pub fn is_file_with_ext(entry: &walkdir::DirEntry, file_ext: &str) -> bool {


### PR DESCRIPTION
What do you think about this sort of thing? What's the point of proof storage without commit?

Proof creation code probably needs to be moved out of `cargo-crev`. I need this sort of thing for `py-crev-lib`.
