### PR TITLE
Ignore vendoring

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+
+* Ignore cargo directory source replacements - this essentially ignores `cargo vendor` and `cargo crev` will not read vendored sources
+
 ## [0.18.0](https://github.com/dpc/crev/compare/cargo-crev-v0.16.1...cargo-crev-v0.17.0) - 2020-04-29
 
 * Faster fetching on `repo fetch ...`

--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -279,9 +279,7 @@ impl Scanner {
         };
 
         let crates_io = self.crates_io()?;
-        let downloads = crates_io
-            .get_downloads_count(&pkg_name, &pkg_version)
-            .ok();
+        let downloads = crates_io.get_downloads_count(&pkg_name, &pkg_version).ok();
 
         let owner_list = crates_io.get_owners(&pkg_name).ok();
         let known_owners = match &owner_list {

--- a/cargo-crev/src/repo.rs
+++ b/cargo-crev/src/repo.rs
@@ -11,7 +11,12 @@ use cargo::{
         InternedString, Package, PackageId, PackageIdSpec, Resolve, SourceId, Workspace,
     },
     ops,
-    util::{self, important_paths::find_root_manifest_for_wd, CargoResult, Rustc},
+    util::{
+        self,
+        config::{Config, ConfigValue},
+        important_paths::find_root_manifest_for_wd,
+        CargoResult, Rustc,
+    },
 };
 use cargo_platform::Cfg;
 use crev_common::convert::OptionDeref;
@@ -264,10 +269,74 @@ fn build_graph<'a>(
     Ok(graph)
 }
 
+/// Modifies the given config so that directory source replacements are removed, and references to them as well.
+///
+/// - For information on directory sources, [see here](https://doc.rust-lang.org/cargo/reference/source-replacement.html#directory-sources)
+/// - For information on source replacement, [see here](https://doc.rust-lang.org/cargo/reference/config.html#source)
+fn prune_directory_source_replacements(
+    config: &mut HashMap<String, ConfigValue>,
+) -> CargoResult<()> {
+    if let Some(ConfigValue::Table(ref mut source_config, _)) = config.get_mut("source") {
+        // To do the pruning, first, generate a graph of registry sources, where the node are the sources, and there is an edge if a source
+        //  defines that it is replaced with another source.
+        // Then, find the directory sources, and traverse the graph in reverse to find all the sources that are directory sources, or reference them
+        //  directly or indirectly.
+        // Then, the found sources can be removed from the config.
+        let mut source_graph = petgraph::Graph::<String, ()>::new();
+        let nodes = source_config
+            .keys()
+            .map(|source_key| {
+                (
+                    source_key.clone(),
+                    source_graph.add_node(source_key.clone()),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        source_config
+            .iter()
+            .for_each(|(source_name, source_config_entry)| {
+                if let ConfigValue::Table(source_config_entry, _) = source_config_entry {
+                    if let Some(ConfigValue::String(replacement, _)) =
+                        source_config_entry.get("replace-with")
+                    {
+                        source_graph.add_edge(
+                            *nodes.get(source_name).unwrap(),
+                            *nodes.get(replacement).unwrap(),
+                            (),
+                        );
+                    }
+                }
+            });
+        source_graph.reverse();
+        let mut source_entries_to_delete: HashSet<String> = HashSet::new();
+        source_graph
+            .externals(petgraph::Direction::Incoming)
+            .filter(|leaf_node| {
+                let leaf_source = &source_graph[*leaf_node];
+                if let ConfigValue::Table(ref source_config_entry, _) = source_config[leaf_source] {
+                    if let Some(ConfigValue::String(_, _)) = source_config_entry.get("directory") {
+                        return true;
+                    }
+                }
+                return false;
+            })
+            .for_each(|leaf_node| {
+                let mut bfs = petgraph::visit::Bfs::new(&source_graph, leaf_node);
+                while let Some(nx) = bfs.next(&source_graph) {
+                    source_entries_to_delete.insert(source_graph[nx].clone());
+                }
+            });
+
+        source_config.retain(|source_name, _| !source_entries_to_delete.contains(source_name));
+    }
+    Ok(())
+}
+
 /// A handle to the current Rust project
 pub struct Repo {
     manifest_path: PathBuf,
-    config: cargo::util::config::Config,
+    config: Config,
     cargo_opts: opts::CargoOpts,
     features_list: Vec<String>,
 }
@@ -285,7 +354,7 @@ impl Repo {
             let cwd = env::current_dir()?;
             find_root_manifest_for_wd(&cwd)?
         };
-        let mut config = cargo::util::config::Config::default()?;
+        let mut config = Config::default()?;
         config.configure(
             0,
             /* quiet */ false,
@@ -297,6 +366,10 @@ impl Repo {
             &cargo_opts.unstable_flags,
             &[],
         )?;
+
+        config.load_values()?;
+        prune_directory_source_replacements(config.values_mut()?)?;
+
         // how it used to be; can't find it anywhere anymore
         // let features_set =
         //     Method::split_features(&[cargo_opts.features.clone().unwrap_or_else(String::new)]);
@@ -637,5 +710,181 @@ impl Repo {
                 .map(|m| m.package_id())
                 .collect())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cargo::util::config::Definition;
+
+    #[test]
+    fn test_prune_directory_source_replacement() {
+        // Test that:
+        // {
+        //     "source": {"crates-io": {"replace-with": my-vendor-source (from --config cli option)},
+        //                "another-source": {"registry": path/to/registry (from --config cli option)},
+        //                "my-vendor-source": {"directory": vendor (from --config cli option)}},
+        // }
+        // becomes:
+        // {
+        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)}},
+        // }
+        //
+        // the "my-vendor-source" should get removed because it's a directory source replacement,
+        // and "crates-io" should get removed because it referenced the removed "my-vendor-source"
+        let crates_io_source_replacement = ConfigValue::Table(
+            [(
+                "replace-with".into(),
+                ConfigValue::String("my-vendor-source".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let directory_replacement = ConfigValue::Table(
+            [(
+                "directory".into(),
+                ConfigValue::String("vendor".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let registry_replacement = ConfigValue::Table(
+            [(
+                "registry".into(),
+                ConfigValue::String("path/to/registry".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let source_table = ConfigValue::Table(
+            [
+                ("crates-io".into(), crates_io_source_replacement),
+                ("my-vendor-source".into(), directory_replacement),
+                ("another-source".into(), registry_replacement.clone()),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let mut config_table = [("source".into(), source_table)].iter().cloned().collect();
+
+        let expected_source_table = ConfigValue::Table(
+            [("another-source".into(), registry_replacement)]
+                .iter()
+                .cloned()
+                .collect(),
+            Definition::Cli,
+        );
+        let expected_config_table = [("source".into(), expected_source_table)]
+            .iter()
+            .cloned()
+            .collect();
+
+        prune_directory_source_replacements(&mut config_table).unwrap();
+        assert_eq!(config_table, expected_config_table);
+    }
+
+    #[test]
+    fn test_prune_directory_source_replacement_nested() {
+        // Test that:
+        // {
+        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)},
+        //                "nested-vendor-source": {"directory": vendor (from --config cli option)},
+        //                "my-vendor-source": {"replace-with": nested-vendor-source (from --config cli option)},
+        //                "crates-io": {"replace-with": my-vendor-source (from --config cli option)}},
+        // }
+        // becomes:
+        // {
+        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)}},
+        // }
+        //
+        // the "nested-vendor-source" should get removed because it's a directory source replacement,
+        // and "my-vendor-source" should get removed because it referenced the removed "nested-vendor-source"
+        // and "crates-io" should get removed because it referenced the removed "my-vendor-source"
+        let crates_io_source_replacement = ConfigValue::Table(
+            [(
+                "replace-with".into(),
+                ConfigValue::String("my-vendor-source".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let nested_replacement = ConfigValue::Table(
+            [(
+                "replace-with".into(),
+                ConfigValue::String("nested-vendor-source".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let directory_replacement = ConfigValue::Table(
+            [(
+                "directory".into(),
+                ConfigValue::String("vendor".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let registry_replacement = ConfigValue::Table(
+            [(
+                "registry".into(),
+                ConfigValue::String("path/to/registry".into(), Definition::Cli),
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let source_table = ConfigValue::Table(
+            [
+                ("crates-io".into(), crates_io_source_replacement),
+                ("my-vendor-source".into(), nested_replacement),
+                ("nested-vendor-source".into(), directory_replacement),
+                ("another-source".into(), registry_replacement.clone()),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            Definition::Cli,
+        );
+
+        let mut config_table = [("source".into(), source_table)].iter().cloned().collect();
+
+        let expected_source_table = ConfigValue::Table(
+            [("another-source".into(), registry_replacement)]
+                .iter()
+                .cloned()
+                .collect(),
+            Definition::Cli,
+        );
+        let expected_config_table = [("source".into(), expected_source_table)]
+            .iter()
+            .cloned()
+            .collect();
+
+        prune_directory_source_replacements(&mut config_table).unwrap();
+        assert_eq!(config_table, expected_config_table);
     }
 }

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -735,10 +735,7 @@ pub fn lookup_crates(query: &str, count: usize) -> Result<()> {
     let local = crev_lib::Local::auto_create_or_open()?;
     let db = local.load_db()?;
 
-    let client = SyncClient::new(
-        "cargo-crev",
-        std::time::Duration::from_millis(1000),
-    )?;
+    let client = SyncClient::new("cargo-crev", std::time::Duration::from_millis(1000))?;
     let mut stats: Vec<_> = client
         .crates(ListOptions {
             sort: Sort::Downloads,

--- a/crev-data/src/id.rs
+++ b/crev-data/src/id.rs
@@ -4,13 +4,10 @@ use crev_common::{
     serde::{as_base64, from_base64},
 };
 use derive_builder::Builder;
-use ed25519_dalek::{self, PublicKey, SecretKey};
-use ed25519_dalek::Signer;
-use ed25519_dalek::Verifier;
+use ed25519_dalek::{self, PublicKey, SecretKey, Signer, Verifier};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IdType {


### PR DESCRIPTION
This sets the cargo config invoked by crev to ignore vendoring. Vendored dependencies have some incompatibilities with crev.

## Vendor incompatibilities
I compared the log crate, version 0.4.8. Folder A is the cached folder via cargo crev crate open log 0.4.8, and folder B is the dependency as vendored by cargo vendor. The differences are below:
- B has /.cargo-checksum.json which A does not
- A has /.cargo-ok which B does not (afaik, this is ignored in digest compute here)
- A has /.cargo_vcs_info.json which B does not
- A has /.gitignore which B does not
- A has /Cargo.toml.orig which B does not.
Also, commands like cargo crev crate open log 0.4.8 fail with:
> Error: failed to download `log v0.4.8`

when run inside a workspace setup for vendored dependencies.

## How this fix works
By ignoring vendoring config, cargo will look for dependencies in its normal folder.
On a dev's machine, this should be optimal since that's where the dependency is unmodified and reviewed from other crev reviews.

This may make it harder to run crev verify on some type of airgapped CI where the build system relies on vendoring - but crev won't work properly in computing the digest on vendored dependencies anyways. This means it's not really a regression imo.

Checklist:

* [x] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable
