### PR TITLE
Fix CI and bump MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ matrix:
 
     # OSX release build
     - env: DEPLOY=1 TARGET=x86_64-apple-darwin OPENSSL_STATIC=yes
-      before_script:
-        - rustup component add rustfmt
       script:
-        - cargo fmt --all -- --check
         - cargo build --locked --release --target $TARGET
       os: osx
 
@@ -24,22 +21,24 @@ matrix:
     - env: DEPLOY=1 TARGET=x86_64-unknown-linux-musl OPENSSL_STATIC=yes
       before_script:
         - rustup target add $TARGET
-        - rustup component add rustfmt
       script:
-        - cargo fmt --all -- --check
         - cargo build --locked --release --target $TARGET
       addons:
         apt:
           packages:
-          - musl-tools
-          - linux-headers-generic
+            - musl-tools
+            - linux-headers-generic
+
+    - name: nightly rustfmt
+      rust: nightly-2020-08-17
+      script:
+        - rustup component add rustfmt
+        - cargo fmt --all -- --check
 
   allow_failures:
     - rust: nightly
 
 script:
-  - rustup component add rustfmt
-  - cargo fmt --all -- --check
   - cargo build --release --locked --verbose
   - RUST_BACKTRACE=1 cargo test --release --locked --all --verbose
   # Requires PR #321
@@ -54,13 +53,11 @@ deploy:
   file_glob: true
   file: cargo-crev-$TRAVIS_TAG-$TARGET.*
   on:
-    condition: $TRAVIS_RUST_VERSION = stable
-    condition: $DEPLOY = 1
+    condition: $TRAVIS_RUST_VERSION = stable && $DEPLOY = 1
     tags: true
   provider: releases
   skip_cleanup: true
 
-cache: cargo
 before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 
     # rustc version compat
     - rust: stable
-    - rust: 1.40.0
+    - rust: 1.43.0
     - rust: nightly
 
     # OSX release build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: nightly
       target: x86_64-pc-windows-msvc
-    - channel: 1.40.0 # Oldest supported version. Keep in sync with README.md.
+    - channel: 1.43.0 # Oldest supported version. Keep in sync with README.md.
       target: x86_64-pc-windows-msvc
 
 before_deploy:

--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -279,9 +279,7 @@ impl Scanner {
         };
 
         let crates_io = self.crates_io()?;
-        let downloads = crates_io
-            .get_downloads_count(&pkg_name, &pkg_version)
-            .ok();
+        let downloads = crates_io.get_downloads_count(&pkg_name, &pkg_version).ok();
 
         let owner_list = crates_io.get_owners(&pkg_name).ok();
         let known_owners = match &owner_list {

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -735,10 +735,7 @@ pub fn lookup_crates(query: &str, count: usize) -> Result<()> {
     let local = crev_lib::Local::auto_create_or_open()?;
     let db = local.load_db()?;
 
-    let client = SyncClient::new(
-        "cargo-crev",
-        std::time::Duration::from_millis(1000),
-    )?;
+    let client = SyncClient::new("cargo-crev", std::time::Duration::from_millis(1000))?;
     let mut stats: Vec<_> = client
         .crates(ListOptions {
             sort: Sort::Downloads,

--- a/crev-data/src/id.rs
+++ b/crev-data/src/id.rs
@@ -4,13 +4,10 @@ use crev_common::{
     serde::{as_base64, from_base64},
 };
 use derive_builder::Builder;
-use ed25519_dalek::{self, PublicKey, SecretKey};
-use ed25519_dalek::Signer;
-use ed25519_dalek::Verifier;
+use ed25519_dalek::{self, PublicKey, SecretKey, Signer, Verifier};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IdType {

--- a/crev-data/src/lib.rs
+++ b/crev-data/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::{
 #[cfg(test)]
 mod tests;
 
-type Result<T, E=Error> = std::result::Result<T, E>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crev-lib/src/lib.rs
+++ b/crev-lib/src/lib.rs
@@ -120,7 +120,7 @@ pub enum Error {
     Id(#[from] IdError),
 }
 
-type Result<T, E=Error> = std::result::Result<T, E>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Trait representing a place that can keep proofs (all reviews and trust proofs)
 ///

--- a/crev-wot/src/lib.rs
+++ b/crev-wot/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Error {
     Data(#[from] crev_data::Error),
 }
 
-type Result<T, E=Error> = std::result::Result<T, E>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Where a proof has been fetched from
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Checklist:

* [x] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable

This fixes both CI, appveyor and travis.
First, moves rustfmt check to its own job and use pinned nightly. Also, removes duplicate keys in the Travis config.
Second, sets MSRV to 1.43.0 to compile deps fine.
