### PR TITLE
add Page Views

### DIFF
--- a/cargo-crev/README.md
+++ b/cargo-crev/README.md
@@ -17,6 +17,7 @@
 ![jesus, that's a lot of unsafe](https://i.imgur.com/nunWPxF.jpg)
 
 # cargo-crev
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fcrev-dev%2Fcargo-crev&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 > A cryptographically verifiable **c**ode **rev**iew system for the cargo (Rust) package manager.
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1635)](https://user-images.githubusercontent.com/47092464/98442773-c6fd1e00-2141-11eb-8710-1cca27b1b2b9.png)
