### PR TITLE
Fix missing `git` subcommand in documentation

### DIFF
--- a/cargo-crev/src/doc/getting_started.md
+++ b/cargo-crev/src/doc/getting_started.md
@@ -552,7 +552,7 @@ Congratulations!
 Every time you create a *proof* `crev` records it in a local copy of your *proof repository* associated with
 your current `CrevID`.
 
-You can access this repository using `cargo crev git` command.
+You can access this repository using `cargo crev repo git` command.
 
 
 ```text


### PR DESCRIPTION
Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable


Trivial fix.
Encountered while setting up Crev for myself.
