### PR TITLE
Replace room ID with #crev

### DIFF
--- a/cargo-crev/README.md
+++ b/cargo-crev/README.md
@@ -5,7 +5,7 @@
   <a href="https://crates.io/crates/cargo-crev">
       <img src="http://meritbadge.herokuapp.com/cargo-crev?style=flat-square" alt="crates.io">
   </a>
-  <a href="https://matrix.to/#/!uBhYhtcoNlyEbzfYAW:matrix.org">
+  <a href="https://matrix.to/#/#crev:matrix.org">
     <img src="https://img.shields.io/matrix/crev:matrix.org.svg?server_fqdn=matrix.org&style=flat-square" alt="crev matrix channel">
   </a>
   <a href="https://gitter.im/dpc/crev">
@@ -48,7 +48,7 @@ Follow the [`cargo-crev` - Getting Started Guide](https://github.com/crev-dev/ca
 (more documentation available on [docs.rs](https://docs.rs/cargo-crev)).
 
 `cargo-crev` is a work in progress, but it should be usable at all times.
-Join our [matrix](https://matrix.to/#/!uBhYhtcoNlyEbzfYAW:matrix.org) or [gitter](https://gitter.im/crev-dev/cargo-crev) channel, get help,
+Join our [matrix](https://matrix.to/#/#crev:matrix.org) or [gitter](https://gitter.im/crev-dev/cargo-crev) channel, get help,
 report problems and feedback. Thank you!
 
 ## Raise awareness

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -853,7 +853,7 @@ pub enum MainCommand {
     #[structopt(name = "crev")]
     #[structopt(after_help = r#"All commands can be abbreviated.
 
-Join Matrix channel for more help at https://matrix.to/#/!uBhYhtcoNlyEbzfYAW:matrix.org
+Join Matrix channel for more help at https://matrix.to/#/#crev:matrix.org
 Read user documentation at https://docs.rs/crate/cargo-crev
         "#)]
     Crev(Command),


### PR DESCRIPTION
Checklist:

* [-] `cargo +nightly fmt --all`
* [-] Modify `CHANGELOG.md` if applicable

This is useful for when room IDs change (due to upgrades or else), and the readmes still point to a room ID instead of an alias.