### PR TITLE
Improve docs for `crev review --diff`

### DIFF
--- a/cargo-crev/src/doc/getting_started.md
+++ b/cargo-crev/src/doc/getting_started.md
@@ -23,6 +23,10 @@ cargo crev publish
 # get more reviews
 cargo crev id query all
 cargo crev trust # insert other people's URLs or Ids here
+
+# review just the parts that changed since
+cargo crev diff $crate_name | less
+cargo crev review --diff $previous_version -- $crate_name
 ```
 
 ## Introduction

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -576,9 +576,10 @@ pub struct CrateReview {
     #[structopt(long = "skip-activity-check")]
     pub skip_activity_check: bool,
 
-    #[structopt(long = "diff")]
+    /// Review the delta since the given version
+    #[structopt(long = "diff", name = "base-version")]
     #[allow(clippy::option_option)]
-    pub diff: Option<Option<crev_data::Version>>,
+    pub diff: Option<Option<Version>>,
 
     #[structopt(flatten)]
     pub cargo_opts: CargoOpts,


### PR DESCRIPTION
I wanted to review a diff and it took me a hot minute to figure out the correct incantation. These changes would've helped me get it done faster. Hopefully they'll help the next person then :)

I couldn't name the option argument "version" because that is already taken by something else — I couldn't figure out by what exactly, but if I use "version", Clap panics at run-time.

Checklist:

* [ ] `cargo +nightly fmt --all` -- this ends up modifying a lot of files which are not related to my changes. Did someone else forgot to do this? Should I do this in a separate commit?
* [x] Modify `CHANGELOG.md` if applicable — I don't think minor doc updates like this are eligible for the changelog entry
