### PR TITLE
Fix interactive use of `trust` and `id trust` to actually read the proofs edited

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fix interactive use of `trust` and `id trust` to actually read the proofs edited
+
 ## [0.21.1](https://github.com/dpc/crev/compare/cargo-crev-v0.18.0...cargo-crev-v0.21.0) - 2020-05-29
 
 - Lots of minor improvements

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -755,7 +755,7 @@ fn set_trust_level_for_ids(
     let local = ensure_crev_id_exists_or_make_one()?;
     let unlocked_id = local.read_current_unlocked_id(&term::read_passphrase)?;
 
-    let trust = local.build_trust_proof(unlocked_id.as_public_id(), ids.to_vec(), trust_level)?;
+    let mut trust = local.build_trust_proof(unlocked_id.as_public_id(), ids.to_vec(), trust_level)?;
 
     if edit_interactively {
         let extra_comment = if trust_level == TrustLevel::Distrust {
@@ -763,7 +763,7 @@ fn set_trust_level_for_ids(
         } else {
             None
         };
-        edit::edit_proof_content_iteractively(&trust, None, None, extra_comment)?;
+        trust = edit::edit_proof_content_iteractively(&trust, None, None, extra_comment)?;
     }
 
     let proof = trust.sign_by(&unlocked_id)?;


### PR DESCRIPTION
Original issue: `trust` without  `--level` option pops up an editor. Setting trust level to `low` and closing the editor caused crev to silently ignore the change and make a trust proof at default `medium`.

Checklist:

* [ ] `cargo +nightly fmt --all` - seem to reformat bunch of unrelated code
* [x] Modify `CHANGELOG.md` if applicable
