### PR TITLE
Exit the program with CommandExitStatus from deps::verify_deps

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -437,7 +437,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 std::process::exit(status.code().unwrap_or(-159));
             }
             opts::Crate::Verify { crate_, opts } => {
-                deps::verify_deps(crate_, opts)?;
+                return deps::verify_deps(crate_, opts);
             }
             opts::Crate::Mvp { crate_, opts } => {
                 deps::crate_mvps(crate_, opts)?;
@@ -627,7 +627,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
         opts::Command::Update(args) => repo_update(args)?,
 
         opts::Command::Verify { crate_, opts } => {
-            deps::verify_deps(crate_, opts)?;
+            return deps::verify_deps(crate_, opts);
         }
     }
 

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -642,6 +642,7 @@ pub fn get_geiger_count(path: &Path) -> Result<u64> {
 ///
 /// This is to distinguish expected non-success results,
 /// from errors: unexpected failures.
+#[must_use]
 pub enum CommandExitStatus {
     // `verify deps` failed
     VerificationFailed,


### PR DESCRIPTION
`deps::verify_deps` returns `CommandExitStatus::VerificationFailed` for `cargo crev verify` if at least one dependency is unverified, but the `?;` consumes the `Result<_>` and discards the inner `CommandExitStatus`:

https://github.com/crev-dev/cargo-crev/blob/f54289128ad8075ebffe47fd080fdac084f51c2e/cargo-crev/src/main.rs#L629-L631

causing a fall-through to:

https://github.com/crev-dev/cargo-crev/blob/f54289128ad8075ebffe47fd080fdac084f51c2e/cargo-crev/src/main.rs#L633-L635

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)