### PR TITLE
Add HTTP Proxy Support

### DIFF
--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -707,7 +707,10 @@ pub fn lookup_crates(query: &str, count: usize) -> Result<()> {
     let local = crev_lib::Local::auto_create_or_open()?;
     let db = local.load_db()?;
 
-    let client = SyncClient::new("cargo-crev", std::time::Duration::from_millis(1000))?;
+    let client = SyncClient::new(
+        "cargo-crev",
+        std::time::Duration::from_secs(1)
+    )?;
     let mut stats: Vec<_> = client
         .crates(ListOptions {
             sort: Sort::Downloads,

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -582,7 +582,7 @@ impl Local {
 
         self.ensure_proofs_root_exists()?;
 
-        match git2::Repository::clone(git_https_url, &proof_dir) {
+        match util::git::clone(git_https_url, &proof_dir) {
             Ok(repo) => {
                 debug!("{} cloned to {}", git_https_url, proof_dir.display());
                 repo.remote_set_url("origin", &push_url)?;
@@ -968,7 +968,7 @@ impl Local {
             let repo = git2::Repository::open(&dir)?;
             util::git::fetch_and_checkout_git_repo(&repo)?
         } else {
-            git2::Repository::clone(url, &dir)?;
+            util::git::clone(url, &dir)?;
         }
 
         Ok(dir)


### PR DESCRIPTION
Support the `http_proxy`, etc. environment variables and the git proxy
config.
