### PR TITLE
Move proofs to the data directory

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased](https://github.com/crev-dev/cargo-crev/compare/v0.22.2...HEAD) - ReleaseDate
 
 - Ignore cargo directory source replacements - this essentially ignores `cargo vendor` and `cargo crev` will not read vendored sources
+- Proofs moved from the config directory (e.g. ~/.config/crev/proofs)
+  to the data directory (e.g. ~/.local/share/crev/proofs).
 
 ## [0.22.2](https://github.com/dpc/crev/compare/cargo-crev-v0.21.4...v0.22.2) - 2022-01-11
 

--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Ignore cargo directory source replacements - this essentially ignores `cargo vendor` and `cargo crev` will not read vendored sources
 - Proofs moved from the config directory (e.g. ~/.config/crev/proofs)
   to the data directory (e.g. ~/.local/share/crev/proofs).
+- Added command `config data-dir`.
+- Added command `config cache-dir`.
 
 ## [0.22.2](https://github.com/dpc/crev/compare/cargo-crev-v0.21.4...v0.22.2) - 2022-01-11
 

--- a/cargo-crev/src/crates_io.rs
+++ b/cargo-crev/src/crates_io.rs
@@ -59,7 +59,7 @@ fn get_downloads_stats(resp: &crates_io_api::CrateResponse, version: &Version) -
 
 impl Client {
     pub fn new(local: &crev_lib::Local) -> Result<Self> {
-        let cache_dir = local.get_root_cache_dir().join("crates_io");
+        let cache_dir = local.cache_root().join("crates_io");
         fs::create_dir_all(&cache_dir)?;
         Ok(Self {
             client: crates_io_api::SyncClient::new(

--- a/cargo-crev/src/deps/print_term.rs
+++ b/cargo-crev/src/deps/print_term.rs
@@ -221,10 +221,7 @@ pub fn print_dep(
     if columns.show_latest_trusted() {
         print!(
             "{:<12}",
-            latest_trusted_version_string(
-                stats.info.id.version(),
-                &details.latest_trusted_version
-            )
+            latest_trusted_version_string(stats.info.id.version(), &details.latest_trusted_version)
         );
     }
 

--- a/cargo-crev/src/info.rs
+++ b/cargo-crev/src/info.rs
@@ -1,4 +1,11 @@
-use crate::{Repo, deps::{AccumulativeCrateDetails, scan::{self, RequiredDetails}}, opts::{CrateSelector, CrateVerify, CrateVerifyCommon}};
+use crate::{
+    deps::{
+        scan::{self, RequiredDetails},
+        AccumulativeCrateDetails,
+    },
+    opts::{CrateSelector, CrateVerify, CrateVerifyCommon},
+    Repo,
+};
 use anyhow::{bail, Result};
 use crev_data::proof;
 use serde::{Deserialize, Serialize};
@@ -94,7 +101,11 @@ pub fn get_crate_info(
         deps: if root_crate.unrelated {
             None
         } else {
-            Some(get_crate_deps_info(pkg_id, common_opts, &RequiredDetails::none())?)
+            Some(get_crate_deps_info(
+                pkg_id,
+                common_opts,
+                &RequiredDetails::none(),
+            )?)
         },
         alternatives: db
             .get_pkg_alternatives(&crev_pkg_id.id)

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -505,6 +505,14 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 let local = crev_lib::Local::auto_create_or_open()?;
                 println!("{}", local.config_root().display());
             }
+            opts::Config::DataDir => {
+                let local = crev_lib::Local::auto_create_or_open()?;
+                println!("{}", local.data_root().display());
+            }
+            opts::Config::CacheDir => {
+                let local = crev_lib::Local::auto_create_or_open()?;
+                println!("{}", local.cache_root().display());
+            }
             opts::Config::Edit => {
                 let local = crev_lib::Local::auto_create_or_open()?;
                 edit::edit_user_config(&local)?;

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -762,7 +762,8 @@ fn set_trust_level_for_ids(
     let local = ensure_crev_id_exists_or_make_one()?;
     let unlocked_id = local.read_current_unlocked_id(&term::read_passphrase)?;
 
-    let mut trust = local.build_trust_proof(unlocked_id.as_public_id(), ids.to_vec(), trust_level)?;
+    let mut trust =
+        local.build_trust_proof(unlocked_id.as_public_id(), ids.to_vec(), trust_level)?;
 
     if edit_interactively {
         let extra_comment = if trust_level == TrustLevel::Distrust {

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -503,7 +503,7 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
         opts::Command::Config(args) => match args {
             opts::Config::Dir => {
                 let local = crev_lib::Local::auto_create_or_open()?;
-                println!("{}", local.get_root_path().display());
+                println!("{}", local.config_root().display());
             }
             opts::Config::Edit => {
                 let local = crev_lib::Local::auto_create_or_open()?;

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -753,6 +753,14 @@ pub enum Config {
     /// Print the dir containing config files
     #[structopt(name = "dir")]
     Dir,
+
+    /// Print the dir containing data files
+    #[structopt(name = "data-dir")]
+    DataDir,
+
+    /// Print the dir containing cache files
+    #[structopt(name = "cache-dir")]
+    CacheDir,
 }
 
 #[derive(Debug, StructOpt, Clone)]

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -707,10 +707,7 @@ pub fn lookup_crates(query: &str, count: usize) -> Result<()> {
     let local = crev_lib::Local::auto_create_or_open()?;
     let db = local.load_db()?;
 
-    let client = SyncClient::new(
-        "cargo-crev",
-        std::time::Duration::from_secs(1)
-    )?;
+    let client = SyncClient::new("cargo-crev", std::time::Duration::from_secs(1))?;
     let mut stats: Vec<_> = client
         .crates(ListOptions {
             sort: Sort::Downloads,

--- a/cargo-crev/tests/clitest.rs
+++ b/cargo-crev/tests/clitest.rs
@@ -1,14 +1,19 @@
-use std::ffi::*;
-use std::io::Write;
-use std::path::*;
-use std::process::*;
+use std::{ffi::*, io::Write, path::*, process::*};
 
 #[test]
 fn creates_new_id_implicitly() {
     let c = Cli::new();
     let empty_id = c.run(&["id", "query", "own"], "");
     assert!(!empty_id.status.success(), "{:?}", empty_id);
-    let trust = c.run(&["id", "trust", "--level=medium", "FYlr8YoYGVvDwHQxqEIs89reKKDy-oWisoO0qXXEfHE"], "");
+    let trust = c.run(
+        &[
+            "id",
+            "trust",
+            "--level=medium",
+            "FYlr8YoYGVvDwHQxqEIs89reKKDy-oWisoO0qXXEfHE",
+        ],
+        "",
+    );
     assert!(trust.status.success(), "{:?}", trust);
     assert!(c.run(&["id", "query", "own"], "").status.success());
 }

--- a/crev-common/src/blake2b256.rs
+++ b/crev-common/src/blake2b256.rs
@@ -25,7 +25,10 @@ impl digest::FixedOutput for Blake2b256 {
         });
     }
 
-    fn finalize_into_reset(&mut self, out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>) {
+    fn finalize_into_reset(
+        &mut self,
+        out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>,
+    ) {
         self.0.finalize_variable_reset(|slice| {
             assert_eq!(slice.len(), 32);
             out.copy_from_slice(slice)

--- a/crev-lib/src/lib.rs
+++ b/crev-lib/src/lib.rs
@@ -347,10 +347,7 @@ pub fn dir_verify(
 }
 
 pub fn get_dir_digest(path: &Path, ignore_list: &fnv::FnvHashSet<PathBuf>) -> Result<Digest> {
-    Ok(Digest::from_vec(util::get_recursive_digest_for_dir(
-        path,
-        ignore_list,
-    )?).unwrap())
+    Ok(Digest::from_vec(util::get_recursive_digest_for_dir(path, ignore_list)?).unwrap())
 }
 
 pub fn get_recursive_digest_for_git_dir(
@@ -390,7 +387,8 @@ pub fn get_recursive_digest_for_dir(
     Ok(Digest::from_vec(util::get_recursive_digest_for_dir(
         root_path,
         rel_path_ignore_list,
-    )?).unwrap())
+    )?)
+    .unwrap())
 }
 
 #[cfg(test)]

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -125,7 +125,7 @@ impl Local {
     }
 
     /// Where the config is stored
-    pub fn get_root_path(&self) -> &Path {
+    pub fn config_root(&self) -> &Path {
         &self.config_path
     }
 
@@ -135,7 +135,7 @@ impl Local {
     }
 
     /// Where temporary files are stored
-    pub fn get_root_cache_dir(&self) -> &Path {
+    pub fn cache_root(&self) -> &Path {
         &self.cache_path
     }
 

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -111,7 +111,8 @@ impl Local {
         let proj_dir = match std::env::var_os("CARGO_CREV_ROOT_DIR_OVERRIDE") {
             None => ProjectDirs::from("", "", "crev"),
             Some(path) => ProjectDirs::from_path(path.into()),
-        }.ok_or(Error::NoHomeDirectory)?;
+        }
+        .ok_or(Error::NoHomeDirectory)?;
         let config_path = proj_dir.config_dir().into();
         let data_path = proj_dir.data_dir().into();
         let cache_path = proj_dir.cache_dir().into();
@@ -539,7 +540,11 @@ impl Local {
         }
         if let Err(e) = git2::Repository::init(&proof_dir) {
             warn!("Can't init repo in {}: {}", proof_dir.display(), e);
-            self.run_git(vec!["init".into(), "--initial-branch=master".into(), proof_dir.into()])?;
+            self.run_git(vec![
+                "init".into(),
+                "--initial-branch=master".into(),
+                proof_dir.into(),
+            ])?;
         }
         Ok(())
     }
@@ -1159,9 +1164,18 @@ impl Local {
             &[]
         };
 
-        let signature = repo.signature().or_else(|_| git2::Signature::now("unconfigured", "nobody@crev.dev"))?;
+        let signature = repo
+            .signature()
+            .or_else(|_| git2::Signature::now("unconfigured", "nobody@crev.dev"))?;
 
-        repo.commit(Some("HEAD"), &signature, &signature, commit_msg, &tree, parents)?;
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            commit_msg,
+            &tree,
+            parents,
+        )?;
 
         Ok(())
     }

--- a/crev-lib/src/util/mod.rs
+++ b/crev-lib/src/util/mod.rs
@@ -2,9 +2,9 @@ use bstr::ByteSlice;
 use crev_common::sanitize_name_for_fs;
 pub use crev_common::{run_with_shell_cmd, store_str_to_file, store_to_file_with};
 use crev_data::proof;
-use std::borrow::Cow;
 use std::{
     self,
+    borrow::Cow,
     ffi::OsStr,
     io,
     path::{Path, PathBuf},
@@ -119,11 +119,11 @@ fn mark_dangerous_name(
             changes
                 .push("rust-toolchain file could unexpectedly replace your compiler".to_string());
             PathBuf::from(format!("{}.CREV", orig_name))
-        },
+        }
         ".cargo-ok" | ".cargo_vcs_info.json" | ".gitignore" => {
             // they're safe
             PathBuf::from(orig_name)
-        },
+        }
         n if n.starts_with('.') => {
             changes.push(format!("Hidden file: '{}'", orig_name));
             PathBuf::from(format!("CREV{}", orig_name))
@@ -184,7 +184,10 @@ pub fn copy_dir_sanitized(
                 let input = std::fs::read(&src_path)?;
                 let output = escape_tricky_unicode(&input);
                 if output != input {
-                    changes.push(format!("Escaped potentially confusing UTF-8 in '{}'", src_path.display()));
+                    changes.push(format!(
+                        "Escaped potentially confusing UTF-8 in '{}'",
+                        src_path.display()
+                    ));
                 }
                 std::fs::write(&dest_path, output)?;
             }
@@ -198,9 +201,24 @@ pub fn copy_dir_sanitized(
 }
 
 fn is_binary_file_extension(path: &Path) -> bool {
-    path.extension().and_then(|e| e.to_str()) .map_or(false, |e| {
-        matches!(e.to_lowercase().as_str(), "bin" | "zip" | "gz" | "xz" | "bz2" | "jpg" | "jpeg" | "png" | "gif" | "exe" | "dll")
-    })
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map_or(false, |e| {
+            matches!(
+                e.to_lowercase().as_str(),
+                "bin"
+                    | "zip"
+                    | "gz"
+                    | "xz"
+                    | "bz2"
+                    | "jpg"
+                    | "jpeg"
+                    | "png"
+                    | "gif"
+                    | "exe"
+                    | "dll"
+            )
+        })
 }
 
 fn escape_tricky_unicode(input: &[u8]) -> Cow<[u8]> {
@@ -226,9 +244,10 @@ fn escape_tricky_unicode_str(input: &str) -> Cow<str> {
     for ch in input.chars() {
         match ch {
             // https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html
-            '\u{202A}' | '\u{202B}' | '\u{202C}' | '\u{202D}' | '\u{202E}' | '\u{2066}' | '\u{2067}' | '\u{2068}' | '\u{2069}' => {
+            '\u{202A}' | '\u{202B}' | '\u{202C}' | '\u{202D}' | '\u{202E}' | '\u{2066}'
+            | '\u{2067}' | '\u{2068}' | '\u{2069}' => {
                 let _ = write!(&mut out, "\\u{{{:04x}}}", ch as u32);
-            } ,
+            }
             _ => out.push(ch),
         }
     }

--- a/crev-wot/src/lib.rs
+++ b/crev-wot/src/lib.rs
@@ -1010,9 +1010,11 @@ impl ProofDB {
     }
 
     fn get_trust_list_of_id(&self, id: &Id) -> impl Iterator<Item = (TrustLevel, &Id)> {
-        self.trust_id_to_id.get(id).map(|map| map.iter().map(|(id, trust)| (trust.value, id)))
-        .into_iter()
-        .flatten()
+        self.trust_id_to_id
+            .get(id)
+            .map(|map| map.iter().map(|(id, trust)| (trust.value, id)))
+            .into_iter()
+            .flatten()
     }
 
     pub fn calculate_trust_set(&self, for_id: &Id, params: &TrustDistanceParams) -> TrustSet {
@@ -1100,7 +1102,10 @@ impl ProofDB {
                 // However banning by the same trust level node, does not prevent
                 // the node from banning others.
                 if direct_trust == TrustLevel::Distrust {
-                    debug!("Adding {} to distrusted list (via {})", candidate_id, current.id);
+                    debug!(
+                        "Adding {} to distrusted list (via {})",
+                        candidate_id, current.id
+                    );
                     // We discard the result, because we actually want to make as much
                     // progress as possible before restaring building the WoT, and
                     // we will not visit any node that was marked as distrusted,


### PR DESCRIPTION
I’ve included a bit extra, and another commit that applies rustfmt to the *rest* of the repository (not my stuff). Decide what you will of it all.

Seemed to work on my machine. Not especially conducive to adding a test case.

See the commit messages.

There wasn’t a consistent style in CHANGELOG.md for me to follow: wrap or not, present or past tense, full stop at end or not. I chose what I think is reasonable, and we can change it if you like.

Fixes #435.