### PR TITLE
Add arguments --none-cost N and --distrust-cost N

### DIFF
--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -161,6 +161,12 @@ pub struct TrustDistanceParams {
     /// [trust-graph-traversal] Cost of traversing trust graph edge of low trust level
     #[structopt(long = "low-cost", default_value = "5")]
     pub low_cost: u64,
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of none trust level
+    #[structopt(long = "none-cost", default_value = "21")]
+    pub none_cost: u64,
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of distrust trust level
+    #[structopt(long = "distrust-cost", default_value = "21")]
+    pub distrust_cost: u64,
 }
 
 impl From<TrustDistanceParams> for crev_lib::TrustDistanceParams {
@@ -170,6 +176,8 @@ impl From<TrustDistanceParams> for crev_lib::TrustDistanceParams {
             high_trust_distance: params.high_cost,
             medium_trust_distance: params.medium_cost,
             low_trust_distance: params.low_cost,
+            none_trust_distance: params.none_cost,
+            distrust_distance: params.distrust_cost,
         }
     }
 }

--- a/crev-wot/src/lib.rs
+++ b/crev-wot/src/lib.rs
@@ -1197,6 +1197,8 @@ pub struct TrustDistanceParams {
     pub high_trust_distance: u64,
     pub medium_trust_distance: u64,
     pub low_trust_distance: u64,
+    pub none_trust_distance: u64,
+    pub distrust_distance: u64,
 }
 
 impl TrustDistanceParams {
@@ -1206,14 +1208,16 @@ impl TrustDistanceParams {
             high_trust_distance: 1,
             medium_trust_distance: 1,
             low_trust_distance: 1,
+            none_trust_distance: 1,
+            distrust_distance: 1,
         }
     }
 
     fn distance_by_level(&self, level: TrustLevel) -> Option<u64> {
         use crev_data::proof::trust::TrustLevel::*;
         Some(match level {
-            Distrust => return Option::None,
-            None => return Option::None,
+            Distrust => self.distrust_distance,
+            None => self.none_trust_distance,
             Low => self.low_trust_distance,
             Medium => self.medium_trust_distance,
             High => self.high_trust_distance,
@@ -1228,6 +1232,8 @@ impl Default for TrustDistanceParams {
             high_trust_distance: 0,
             medium_trust_distance: 1,
             low_trust_distance: 5,
+            none_trust_distance: 11,
+            distrust_distance: 11,
         }
     }
 }

--- a/crev-wot/src/tests.rs
+++ b/crev-wot/src/tests.rs
@@ -58,6 +58,8 @@ fn proofdb_distance() -> Result<()> {
         high_trust_distance: 1,
         medium_trust_distance: 10,
         low_trust_distance: 100,
+        none_trust_distance: 112,
+        distrust_distance: 112,
         max_distance: 111,
     };
     let mut trustdb = ProofDB::new();
@@ -180,6 +182,8 @@ fn proofdb_distrust() -> Result<()> {
         high_trust_distance: 1,
         medium_trust_distance: 10,
         low_trust_distance: 100,
+        none_trust_distance: 10001,
+        distrust_distance: 10001,
         max_distance: 10000,
     };
     let mut trustdb = ProofDB::new();
@@ -228,6 +232,8 @@ fn proofdb_trust_ignore_override() -> Result<()> {
         high_trust_distance: 1,
         medium_trust_distance: 10,
         low_trust_distance: 100,
+        none_trust_distance: 10001,
+        distrust_distance: 10001,
         max_distance: 10000,
     };
 

--- a/crev-wot/src/trust_set.rs
+++ b/crev-wot/src/trust_set.rs
@@ -214,7 +214,7 @@ impl TrustSet {
                     .unwrap_or_else(HashSet::new);
 
                 let too_far = candidate_total_distance.map(|d| params.max_distance < d);
-                let trust_too_low = effective_trust_level == TrustLevel::None;
+                let trust_too_low = too_far.unwrap_or(true) && effective_trust_level == TrustLevel::None;
 
                 let overriden_by = if let Some(existing_override) = current_trust_set
                     .trust_ignore_overrides
@@ -241,7 +241,7 @@ impl TrustSet {
                     distrusted_by: distrusted_by.clone(),
                     overriden_by: overriden_by.clone(),
 
-                    ignored_distrusted: !distrusted_by.is_empty(),
+                    ignored_distrusted: too_far.unwrap_or(true) && !distrusted_by.is_empty(),
                     ignored_too_far: too_far.unwrap_or(true),
                     ignored_trust_too_low: trust_too_low,
                     ignored_overriden: !overriden_by.is_empty(),


### PR DESCRIPTION
to be able to walk those in the WoT. Their effect is normally disabled
by having their default be higher than the maximum depth/cost.

If e.g. one would like to know if there is any review out there for a
crate, I trust some proof repos with level none. With this change I can
then download every repo I can see:

crev repo fetch trusted --none-cost 4

Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
