### PR TITLE
Fix working directory checks for clean and review

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased](https://github.com/crev-dev/cargo-crev/compare/v0.23.0...HEAD) - ReleaseDate
 
 - Fix crash on systems with libgit2 v1.4
+- Fix the `crate clean` working directory check.
 
 
 ## [0.23.0](https://github.com/crev-dev/cargo-crev/compare/v0.22.2...v0.23.0) - 2022-01-22

--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix crash on systems with libgit2 v1.4
 - Fix the `crate clean` working directory check.
+- Fix the `crate review` working directory check.
 
 
 ## [0.23.0](https://github.com/crev-dev/cargo-crev/compare/v0.22.2...v0.23.0) - 2022-01-22

--- a/cargo-crev/src/review.rs
+++ b/cargo-crev/src/review.rs
@@ -36,7 +36,11 @@ pub fn create_review_proof(
     let crate_root = crate_.root();
     let effective_crate_version = crate_.version();
 
-    assert!(!crate_root.starts_with(std::env::current_dir()?));
+    assert!(
+        !std::env::current_dir()?.starts_with(crate_root),
+        "Cannot create review proof while inside {}.",
+        crate_root.display(),
+    );
     let local = Local::auto_open()?;
 
     let diff_base_version = match crate_review_activity_check(

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -232,7 +232,11 @@ pub fn clean_crate(selector: &CrateSelector) -> Result<()> {
     let crate_root = crate_.root();
 
     assert!(crate_root.is_absolute());
-    assert!(!crate_root.starts_with(std::env::current_dir()?));
+    assert!(
+        !std::env::current_dir()?.starts_with(crate_root),
+        "Cannot delete {} while inside that directory.",
+        crate_root.display(),
+    );
 
     if crate_root.is_dir() {
         std::fs::remove_dir_all(&crate_root)?;


### PR DESCRIPTION
The checks were back to front, checking that the crate root wasn’t in the current directory, rather than that the current directory wasn’t in the crate root.

See the commit messages for more details.