### PR TITLE
Fix cmdline help of "verify --dev-dependencies"

### DIFF
--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -91,7 +91,7 @@ pub struct CargoOpts {
     pub no_default_features: bool,
 
     #[structopt(long = "dev-dependencies")]
-    /// [cargo] Skip dev dependencies.
+    /// [cargo] Activate dev dependencies.
     dev_dependencies: bool,
 
     #[structopt(long = "no-dev-dependencies")]


### PR DESCRIPTION
Small drive-by commit while chasing a different problem.

Checklist:

* [x] `cargo fmt --all` (no +nightly switch here)
* [x] Modify `CHANGELOG.md` if applicable -> to minor to mention
