### PR TITLE
Add new "proof reissue" command

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 <!-- next-url -->
 ## [Unreleased](https://github.com/crev-dev/cargo-crev/compare/v0.23.0...HEAD) - ReleaseDate
 
+- Added command "proof reissue" to reissue reviews under a different id.
+  The original proof will be referenced in the new proof under the "original:" field
 - Fix crash on systems with libgit2 v1.4
 - Fix the `crate clean` working directory check.
 - Fix the `crate review` working directory check.

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -866,6 +866,30 @@ pub struct ProofFind {
 }
 
 #[derive(Debug, StructOpt, Clone)]
+pub struct ProofReissue {
+    #[structopt(name = "crate", long = "crate")]
+    pub crate_: Option<String>,
+
+    #[structopt(name = "vers", long = "vers")]
+    pub version: Option<Version>,
+
+    /// Reissue all proofs by a crev Id. Mandatory.
+    #[structopt(name = "author", long = "author")]
+    pub author: String,
+
+    /// Comment for human readers. Mandatory.
+    #[structopt(name = "comment", long = "comment")]
+    pub comment: String,
+
+    /// Skip check if we already reissued a review using the current id
+    #[structopt(long = "skip-reissue-check")]
+    pub skip_reissue_check: bool,
+
+    #[structopt(flatten)]
+    pub common_proof_create: CommonProofCreate,
+}
+
+#[derive(Debug, StructOpt, Clone)]
 /// Local Proof Repository
 pub enum Repo {
     /// Publish to remote repository
@@ -914,6 +938,9 @@ pub enum Proof {
     /// Find a proof
     #[structopt(name = "find")]
     Find(ProofFind),
+    /// Reissue proofs with current id
+    #[structopt(name = "reissue")]
+    Reissue(ProofReissue),
 }
 
 #[derive(Debug, StructOpt, Clone)]

--- a/cargo-crev/src/review.rs
+++ b/cargo-crev/src/review.rs
@@ -199,6 +199,11 @@ pub fn create_review_proof(
 
     review.alternatives = db.get_pkg_alternatives_by_author(&id.id.id, &review.package.id.id);
 
+    // clear "original" reference when overwriting a review
+    if previous_date.is_some() {
+        review.common.original = None;
+    }
+
     let mut review = edit::edit_proof_content_iteractively(
         &review,
         previous_date.as_ref(),

--- a/crev-data/src/proof/content.rs
+++ b/crev-data/src/proof/content.rs
@@ -2,7 +2,7 @@ use crate::{proof, proof::Proof, Error, ParseError, Result};
 use chrono::{self, prelude::*};
 use crev_common::{
     self,
-    serde::{as_rfc3339_fixed, from_rfc3339_fixed},
+    serde::{as_base64, as_rfc3339_fixed, from_base64, from_rfc3339_fixed},
 };
 use derive_builder::Builder;
 use serde::{self, Deserialize, Serialize};
@@ -54,6 +54,16 @@ pub trait CommonOps {
     }
 }
 
+/// Reference to original proof when reissuing
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OriginalReference {
+    /// original proof digest (blake2b256)
+    #[serde(serialize_with = "as_base64", deserialize_with = "from_base64")]
+    pub proof: Vec<u8>,
+    #[serde(skip_serializing_if = "String::is_empty", default = "Default::default")]
+    pub comment: String,
+}
+
 /// A `Common` part of every `Content` format
 #[derive(Clone, Builder, Debug, Serialize, Deserialize)]
 pub struct Common {
@@ -70,6 +80,9 @@ pub struct Common {
     pub date: chrono::DateTime<FixedOffset>,
     /// Author of the proof
     pub from: crate::PublicId,
+    /// Reference to original proof when reissuing
+    #[serde(skip_serializing_if = "Option::is_none", default = "Option::default")]
+    pub original: Option<OriginalReference>,
 }
 
 impl CommonOps for Common {

--- a/crev-data/src/proof/mod.rs
+++ b/crev-data/src/proof/mod.rs
@@ -26,6 +26,9 @@ const MAX_PROOF_BODY_LENGTH: usize = 32_000;
 pub type Date = chrono::DateTime<FixedOffset>;
 pub type DateUtc = chrono::DateTime<Utc>;
 
+#[derive(Debug, Clone)]
+pub struct Digest(pub [u8; 32]);
+
 /// Serialized Proof
 ///
 /// A signed proof containing some signed `Content`
@@ -41,6 +44,7 @@ pub struct Proof {
     common_content: Common,
 
     /// Digest (blake2b256)
+    /// TODO: Use Digest newtype here
     digest: [u8; 32],
 }
 

--- a/crev-data/src/proof/review/code.rs
+++ b/crev-data/src/proof/review/code.rs
@@ -67,6 +67,7 @@ impl CodeBuilder {
                 version: cur_version(),
                 date: crev_common::now(),
                 from: value.into(),
+                original: None,
             });
         }
         self

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -1,7 +1,7 @@
 use crate::{
     proof::{
         self,
-        content::{ValidationError, ValidationResult},
+        content::{OriginalReference, ValidationError, ValidationResult},
         OverrideItem, OverrideItemDraft,
     },
     serde_content_serialize, serde_draft_serialize, Error, Level, ParseError,
@@ -112,6 +112,7 @@ impl PackageBuilder {
                 version: cur_version(),
                 date: crev_common::now(),
                 from: value.into(),
+                original: None,
             });
         }
         self
@@ -144,6 +145,21 @@ impl proof::CommonOps for Package {
 impl Package {
     pub fn touch_date(&mut self) {
         self.common.date = crev_common::now();
+    }
+
+    pub fn change_from(&mut self, id: crate::PublicId) {
+        self.common.from = id;
+    }
+
+    pub fn set_original_reference(&mut self, orig_reference: OriginalReference) {
+        self.common.original = Some(orig_reference);
+    }
+
+    pub fn ensure_kind_is_backfilled(&mut self) {
+        if self.common.kind.is_none() {
+            // backfill "kind" for old reviews. Don't use common().kind() here, it will panic.
+            self.common.kind = Some(self.kind().to_string());
+        }
     }
 }
 

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -119,6 +119,7 @@ impl TrustBuilder {
                 version: cur_version(),
                 date: crev_common::now(),
                 from: value.into(),
+                original: None,
             });
         }
         self


### PR DESCRIPTION
PoC implementation for this discussion: https://github.com/crev-dev/cargo-crev/discussions/492
"How to deal with a person leaving an organization?"

This commands allows to find existing proofs
and sign them again with a different id.

This comes in handy when an id is going be revoked but
the trust of the existing reviews should be retained by a new id.

Scenarios:
- Old id got compromised
- Person leaves an organization, so organization can reissue
  existing reviews using a different id to maintain trust level.

Checklist:

* [x] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable

Code is originally based upon the "proof find" code.