### PR TITLE
Build on macOS+nix, without native libraries globally installed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,10 @@
             fenix-channel.clippy
           ] ++ lib.optionals stdenv.isDarwin [
             libiconv
+            curl
+            libgit2
             darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.CoreFoundation
           ];
 
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Fixes https://github.com/crev-dev/cargo-crev/issues/515

Checklist:

* [x] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable
