### PR TITLE
Explain possible trust level values in help and error messages.

### DIFF
--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -454,7 +454,8 @@ pub struct TrustUrls {
     /// Public IDs or proof repo URLs to create Trust Proof for
     pub public_ids_or_urls: Vec<String>,
 
-    /// Shortcut for setting trust level without editing
+    /// Shortcut for setting trust level without editing.
+    /// Possible values are: "none" or "untrust", "low", "medium", "high" and "distrust".
     #[structopt(long = "level")]
     pub level: Option<crev_data::TrustLevel>,
 

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -46,7 +46,7 @@ impl fmt::Display for TrustLevel {
 }
 
 #[derive(thiserror::Error, Debug)]
-#[error("Can't convert string to TrustLevel")]
+#[error("Can't convert string to TrustLevel. Possible values are: \"none\" or \"untrust\", \"low\", \"medium\", \"high\" and \"distrust\".")]
 pub struct FromStrErr;
 
 impl std::str::FromStr for TrustLevel {


### PR DESCRIPTION
Explain possible trust level values in help and error messages. These help/error messages are shown with `cargo crev trust --help` and upon passing a unexpected parameter with `cargo crev trust --level foo`.

```
$ cargo crev trust --level --help
cargo-crev-trust 0.23.3
Add a Trust proof by an Id or a URL

USAGE:
    cargo crev trust [FLAGS] [OPTIONS] [public-ids-or-urls]...

FLAGS:
    -h, --help              Prints help information
        --no-commit         Don't auto-commit local Proof Repository
        --no-store          Don't store the proof
        --overrides         Enable overrides suggestions
        --print-signed      Print signed proof content on stdout
        --print-unsigned    Print unsigned proof content on stdout
    -V, --version           Prints version information

OPTIONS:
        --level <level>    Shortcut for setting trust level without editing. Possible values are: "none" or "untrust",
                           "low", "medium", "high" and "distrust"

ARGS:
    <public-ids-or-urls>...    Public IDs or proof repo URLs to create Trust Proof for
```

```
cargo crev trust --level foo
error: Invalid value for '--level <level>': Can't convert string to TrustLevel. Possible values are: "none" or "untrust", "low", "medium", "high" and "distrust".
```

### Background:
The getting started guide mentions the `trust` command at the very start: https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md I wanted immediately to add some other users too, but not necessarily at the "high" trust level. But at this point, I have no clue what the other levels are. Thus, it would be helpful for the inline help and error messages to explain about the available values.

### Checklist:

* [X] `cargo +nightly fmt --all`
* [X] Modify `CHANGELOG.md` if applicable