### PR TITLE
Fix --skip-known-owners

### DIFF
--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -340,14 +340,7 @@ pub fn verify_deps(crate_: CrateSelector, args: CrateVerify) -> Result<CommandEx
     let mut crates_with_issues = false;
 
     let deps: Vec<_> = events
-        .filter(|stats| {
-            !args.skip_known_owners
-                || stats
-                    .details
-                    .known_owners
-                    .map(|it| it.count == 0)
-                    .unwrap_or(true)
-        })
+        .filter(|stats| !args.skip_known_owners || !crate_has_known_owner(stats))
         .filter(|stats| !args.skip_verified || !stats.details.accumulative.verified)
         .map(|stats| {
             print_term::print_dep(
@@ -460,4 +453,11 @@ fn write_out_distrusted_ids_details(
         }
     }
     Ok(())
+}
+
+fn crate_has_known_owner(stats: &CrateStats) -> bool {
+    match stats.details.known_owners {
+        Some(known_owners) => known_owners.count > 0,
+        None => false,
+    }
 }

--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -346,7 +346,7 @@ pub fn verify_deps(crate_: CrateSelector, args: CrateVerify) -> Result<CommandEx
                     .details
                     .known_owners
                     .map(|it| it.count == 0)
-                    .unwrap_or(false)
+                    .unwrap_or(true)
         })
         .filter(|stats| !args.skip_verified || !stats.details.accumulative.verified)
         .map(|stats| {

--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -327,7 +327,7 @@ pub fn verify_deps(crate_: CrateSelector, args: CrateVerify) -> Result<CommandEx
 
     let events = scanner.run(&RequiredDetails {
         geiger: args.columns.show_geiger(),
-        owners: args.columns.show_owners(),
+        owners: args.columns.show_owners() || args.skip_known_owners,
         downloads: args.columns.show_downloads() || args.columns.show_leftpad_index(),
         loc: args.columns.show_loc() || args.columns.show_leftpad_index(),
     });


### PR DESCRIPTION
## The problem

I noticed that `cargo crev verify --skip-known-owners` always returns an empty list, even when crates without any known owners are part of the dependencies.

## The fix

This pull request contains three commits:
  1. The fix for the concrete problem.
  2. A patch to make `--skip-known-owners` more robust if no owner list is available: Instead of assuming that there _are_ known authors, it is now assumed that there are _no_ known authors.
  3. A small local refactor to make the decision logic more obvious.

Feel free to pick what you actually want to merge :-)

## Checklist:

* [x] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
