### PR TITLE
Do not fetch anything after `cargo crev trust`

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -538,8 +538,6 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 args.level.is_none(),
                 args.overrides,
             )?;
-            // Make sure we have reviews for the new Ids we're trusting
-            local.fetch_new_trusted(Default::default(), None)?;
         }
         opts::Command::Crate(args) => match args {
             opts::Crate::Diff(args) => {


### PR DESCRIPTION
I have just spent a bunch of time investigating a spooky error of not being able to fetch unrelated URL, after I was signing a trust proof.

Fetching after creating new trust proof is a bit too much automation. It also delays the completion of the actual operation that was invoked.
