### PR TITLE
add support for hidden toolchain file

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix crash on systems with libgit2 v1.4
 - Fix the `crate clean` working directory check.
 - Fix the `crate review` working directory check.
+- Added support for the `.rust-toolchain.toml` file.
 
 
 ## [0.23.0](https://github.com/crev-dev/cargo-crev/compare/v0.22.2...v0.23.0) - 2022-01-22

--- a/crev-lib/src/util/mod.rs
+++ b/crev-lib/src/util/mod.rs
@@ -115,7 +115,7 @@ fn mark_dangerous_name(
             changes.push("cargo/config can replace linkers, source of dependencies".to_string());
             PathBuf::from("config.CREV")
         }
-        "rust-toolchain" | "rust-toolchain.toml" => {
+        "rust-toolchain" | "rust-toolchain.toml" | ".rust-toolchain.toml" => {
             changes
                 .push("rust-toolchain file could unexpectedly replace your compiler".to_string());
             PathBuf::from(format!("{orig_name}.CREV"))


### PR DESCRIPTION
When rustup adds support for the `.rust-toolchain.toml` file ([PR](https://github.com/rust-lang/rustup/pull/3195)) this can be applied.

Checklist:

* [x] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable (or should it be removed?)
