### PR TITLE
 fix: hangs on circular deps and --dev-dependencies flag 

### DIFF
--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -25,6 +25,8 @@ use std::{
         atomic::{self, AtomicBool, Ordering},
         Arc, Mutex,
     },
+    thread::sleep,
+    time::Duration,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -245,6 +247,7 @@ impl Scanner {
                                 for dep_pkg_id in graph.get_dependencies_of(pkg_id) {
                                     if !crate_details_by_id.contains_key(&dep_pkg_id) {
                                         drop(crate_details_by_id);
+                                        sleep(Duration::from_millis(100));
                                         if let Some(pending_tx) =
                                             pending_tx.lock().unwrap().as_mut()
                                         {

--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -16,6 +16,7 @@ use crev_data::proof::{self, CommonOps};
 use crev_lib::{self, VerificationStatus};
 use crev_wot::{self, *};
 use crossbeam::{self, channel::unbounded};
+use log::debug;
 use std::{
     collections::{HashMap, HashSet},
     default::Default,
@@ -243,9 +244,11 @@ impl Scanner {
 
                                 for dep_pkg_id in graph.get_dependencies_of(pkg_id) {
                                     if !crate_details_by_id.contains_key(&dep_pkg_id) {
+                                        drop(crate_details_by_id);
                                         if let Some(pending_tx) =
                                             pending_tx.lock().unwrap().as_mut()
                                         {
+                                            debug!("Postponing {pkg_id} as dependency {dep_pkg_id} is not ready");
                                             pending_tx.send(pkg_id).unwrap();
                                         }
                                         return;
@@ -255,18 +258,22 @@ impl Scanner {
 
                             let info = self_clone.crate_info_by_id[&pkg_id].clone();
 
+                            debug!("Get details of {pkg_id}");
                             let details = self_clone
                                 .get_crate_details(&info, &required_details)
                                 .expect("Unable to scan crate");
                             {
+                                debug!("Insert details of {pkg_id}");
                                 let mut crate_details_by_id =
                                     self_clone.crate_details_by_id.lock().unwrap();
                                 crate_details_by_id.insert(info.id, details.clone());
+                                debug!("Inserted details of {pkg_id}");
                             }
 
                             if self_clone.selected_crates_ids.contains(&pkg_id) {
                                 let stats = CrateStats { info, details };
 
+                                debug!("Send details of {pkg_id} as ready");
                                 // ignore any problems if the receiver decided not to listen anymore
                                 let _ = ready_tx.send(stats);
 

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -42,6 +42,7 @@ use crate::{repo::*, review::*, shared::*};
 use crev_data::{proof, Id, TrustLevel};
 use crev_lib::TrustProofType;
 use crev_wot::{PkgVersionReviewId, ProofDB, TrustSet, UrlOfId};
+use log::debug;
 
 /// Additional functions to extend `Local` by behaviors
 /// that are `cargo-crev` specific, like printing
@@ -1079,6 +1080,7 @@ fn main() {
             }
         })
         .init();
+    debug!("Starting cargo-crev");
     let opts = opts::Opts::from_args();
     let opts::MainCommand::Crev(command) = opts.command;
     handle_command_result_and_panics(|| run_command(command))

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use crev_data::{Level, Version};
-use std::{ffi::OsString, io::Write, path::PathBuf};
+use std::{ffi::OsString, path::PathBuf};
 use structopt::StructOpt;
 use term::color;
 
@@ -117,9 +117,6 @@ impl CargoOpts {
     pub fn dev_dependencies(&self) -> Result<bool> {
         if self.dev_dependencies && self.no_dev_dependencies {
             bail!("`--no-dev-dependencies` and `--dev-dependencies` can't be used together");
-        }
-        if self.no_dev_dependencies {
-            writeln!(std::io::stderr(), "`--no-dev-dependencies` is the default, is now ignored and will be removed in the future")?;
         }
 
         Ok(self.dev_dependencies)

--- a/crev-data/src/level.rs
+++ b/crev-data/src/level.rs
@@ -1,19 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Level {
     None,
     Low,
+    #[default]
     Medium,
     High,
-}
-
-impl Default for Level {
-    fn default() -> Self {
-        Level::Medium
-    }
 }
 
 impl fmt::Display for Level {

--- a/crev-data/src/proof/mod.rs
+++ b/crev-data/src/proof/mod.rs
@@ -203,17 +203,12 @@ impl Proof {
     pub fn parse_from(reader: impl io::Read) -> Result<Vec<Self>> {
         let reader = std::io::BufReader::new(reader);
 
-        #[derive(PartialEq, Eq)]
+        #[derive(PartialEq, Eq, Default)]
         enum Stage {
+            #[default]
             None,
             Body,
             Signature,
-        }
-
-        impl Default for Stage {
-            fn default() -> Self {
-                Stage::None
-            }
         }
 
         #[derive(Default)]

--- a/crev-data/src/proof/review/mod.rs
+++ b/crev-data/src/proof/review/mod.rs
@@ -8,20 +8,15 @@ use std::default::Default;
 pub mod code;
 pub mod package;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Rating {
     #[serde(alias = "dangerous")] // for backward compat with some previous versions
     Negative,
+    #[default]
     Neutral,
     Positive,
     Strong,
-}
-
-impl Default for Rating {
-    fn default() -> Self {
-        Rating::Neutral
-    }
 }
 
 /// Information about review result

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -334,11 +334,12 @@ impl fmt::Display for Draft {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum VersionRange {
     Minor,
     Major,
+    #[default]
     All,
 }
 
@@ -348,12 +349,6 @@ pub struct VersionRangeParseError(());
 impl fmt::Display for VersionRangeParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Could not parse an incorrect advisory range value")
-    }
-}
-
-impl Default for VersionRange {
-    fn default() -> Self {
-        VersionRange::All
     }
 }
 

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -16,20 +16,15 @@ fn cur_version() -> i64 {
     CURRENT_TRUST_PROOF_SERIALIZATION_VERSION
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum TrustLevel {
     Distrust,
     None,
     Low,
+    #[default]
     Medium,
     High,
-}
-
-impl Default for TrustLevel {
-    fn default() -> Self {
-        TrustLevel::Medium
-    }
 }
 
 impl fmt::Display for TrustLevel {

--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1661581637,
-        "narHash": "sha256-Z1FtMPFoUUGqedmwpdXycRrQsVPvJk1LByOcd+FhTuc=",
+        "lastModified": 1679120542,
+        "narHash": "sha256-NqulL85Yk/5fF7Tw3CIN8E6Xf6c6u36r1yXo4rbjS74=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "962dafad624929bf713b6e9da38aeb8818da219e",
+        "rev": "e9afa9455d7a6505d7d13fe8e038e430bbf149d0",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -107,16 +107,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661617163,
-        "narHash": "sha256-NN9Ky47j8ohgPhA9JZyfkYIbbAo6RJkGz+7h8/exVpE=",
+        "lastModified": 1678972866,
+        "narHash": "sha256-YV8BcNWfNVgS449B6hFYFUg4kwVIQMNehZP+FNDs1LY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ba2543f8c855d7be8e90ef6c8dc89c1617e8a08",
+        "rev": "cd34d6ed7ba7d5c4e44b04a53dc97edb52f2766c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -133,11 +133,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1661539193,
-        "narHash": "sha256-LJ+Ry218HavJKZDBpexiASLE4k1k4nhaZv8qb1YvG5Y=",
+        "lastModified": 1678888936,
+        "narHash": "sha256-xs5tbRf0k1RA9li0rM7k1ar0sG5DHp9+rpAP7sjhsNw=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "6bea872edd9523a06213270f68725c9fe33f3919",
+        "rev": "924d277f32b53219fcaa03226c17b485a081ed16",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Cryptographically verifiable Code REviews";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     crane.url = "github:ipetkov/crane";
     crane.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
I investigated a case of hang during `cargo crev verify` and it
came down to a circular dependency caused by dev depencencies
between local crates in a workspace.

I decided to fix it by ignoring dev dependencies between local
crates while building the graph of dependencies from the Cargo's
`resolve`, which made me realize that I can make `--dev-dependencies`
/`--no-dev-dependencies` work, by filtering them conditionally
in the same place.

Every time I touch this areas it comes to bite me later, but the hang
is gone, and I tested `--dev-dependencies` in a couple of places
and it seems to work OK now.