### PR TITLE
fix: "No such file or directory" on `trust` before first ids

### DIFF
--- a/crev-common/src/blake2b256.rs
+++ b/crev-common/src/blake2b256.rs
@@ -1,4 +1,4 @@
-use blake2::Blake2b;
 use blake2::digest::consts::U32;
+use blake2::Blake2b;
 
 pub type Blake2b256 = Blake2b<U32>;


### PR DESCRIPTION
Fix #598