### PR TITLE
Repoint master branch links and mentions

### DIFF
--- a/cargo-crev/README.md
+++ b/cargo-crev/README.md
@@ -54,7 +54,7 @@ Static binaries are available from the [releases
 page](https://github.com/crev-dev/cargo-crev/releases).
 
 Follow the [`cargo-crev` - Getting Started
-Guide](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md)
+Guide](https://github.com/crev-dev/cargo-crev/blob/main/cargo-crev/src/doc/getting_started.md)
 (more documentation available on [docs.rs](https://docs.rs/cargo-crev)).
 
 `cargo-crev` is a work in progress, but it should be usable at all times.
@@ -76,4 +76,4 @@ Thank you\!
 ## Changelog
 
 Changelog can be found here:
-<https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/CHANGELOG.md>
+<https://github.com/crev-dev/cargo-crev/blob/main/cargo-crev/CHANGELOG.md>

--- a/cargo-crev/src/doc/compiling.md
+++ b/cargo-crev/src/doc/compiling.md
@@ -69,7 +69,7 @@ To compile and install latest `cargo-crev` release use `cargo`:
 cargo install cargo-crev
 ```
 
-In case you'd like to try latest features from the master branch, try:
+In case you'd like to try latest features from the main branch, try:
 
 ``` bash
 cargo install --git https://github.com/crev-dev/cargo-crev/ cargo-crev

--- a/cargo-crev/src/doc/getting_started.md
+++ b/cargo-crev/src/doc/getting_started.md
@@ -41,7 +41,7 @@ projects' dependencies.
 Crev is
 [language-independent](https://github.com/crev-dev/crev/#implementations), but
 the primary implementation is [`cargo
-crev`](https://github.com/crev-dev/cargo-crev/tree/master/cargo-crev) for
+crev`](https://github.com/crev-dev/cargo-crev/tree/main/cargo-crev) for
 Rust/[Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) crates.
 
 > This project and documentation is a work in progress. If anything is missing,
@@ -213,7 +213,7 @@ comment: ""
 
 You can edit it to customize the relationship. Editing the proof is modeled
 after editing a commit message through `git commit`. As you can see [helpful
-documentation](https://github.com/crev-dev/cargo-crev/blob/master/crev-lib/rc/doc/editing-trust.md)
+documentation](https://github.com/crev-dev/cargo-crev/blob/main/crev-lib/rc/doc/editing-trust.md)
 is available in the editor.
 
 ## Creating a `CrevID`
@@ -408,7 +408,7 @@ comment: ""
 
 Again, a helpful comment section documents the basic guidelines of *review
 proof*, read it
-[here](https://github.com/crev-dev/cargo-crev/blob/master/crev-lib/rc/doc/editing-package-review.md).
+[here](https://github.com/crev-dev/cargo-crev/blob/main/crev-lib/rc/doc/editing-package-review.md).
 
 The most important part is: just be truthful.
 

--- a/cargo-crev/src/doc/mod.rs
+++ b/cargo-crev/src/doc/mod.rs
@@ -12,7 +12,7 @@
 /// mistakes or ways to make improvements:
 ///
 /// 1. Open
-/// [user documentation source code directory](https://github.com/crev-dev/cargo-crev/tree/master/cargo-crev/src/doc),
+/// [user documentation source code directory](https://github.com/crev-dev/cargo-crev/tree/main/cargo-crev/src/doc),
 /// 2. Open the affected file,
 /// 3. Use *Edit this file* function,
 /// 4. Modify the text,

--- a/crevette/README.md
+++ b/crevette/README.md
@@ -6,7 +6,7 @@ This tool ([`crevette`](https://lib.rs/crevette)) is a helper for `cargo-crev` u
 
 ## Installation
 
-You must have [`cargo-crev` alredy set up](https://github.com/crev-dev/cargo-crev/blob/master/cargo-crev/src/doc/getting_started.md), some [repos added as trusted](https://github.com/crev-dev/cargo-crev/wiki/List-of-Proof-Repositories) and reviews fetched (try `cargo crev repo fetch all`).
+You must have [`cargo-crev` alredy set up](https://github.com/crev-dev/cargo-crev/blob/main/cargo-crev/src/doc/getting_started.md), some [repos added as trusted](https://github.com/crev-dev/cargo-crev/wiki/List-of-Proof-Repositories) and reviews fetched (try `cargo crev repo fetch all`).
 
 It requires the latest stable version of Rust. If your package manager has an outdated version of Rust, switch to [rustup](https://rustup.rs).
 


### PR DESCRIPTION
The master branch was renamed on GitHub - links from documentation (etc.) needs to be updated to point to the main branch without GitHub 
putting up a warning banner.

(cargo format not done as no code change)

Checklist:

* [ ] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable
