### PR TITLE
fix(deps): use index-guix dependency from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,8 @@ dependencies = [
 [[package]]
 name = "index-guix"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5527d0b9a90f16299c4db9a1c93c74089abe2e38dbd640b69e4afc378038e3"
 dependencies = [
  "gix 0.55.2",
  "nom",

--- a/crevette/Cargo.toml
+++ b/crevette/Cargo.toml
@@ -23,7 +23,7 @@ toml_edit = { version = "0.21.0", features = ["serde"] }
 cargo_author = { version = "1.0.6", optional = true }
 flate2 = { version = "1.0.28", optional = true }
 index-debcargo = { version = "1.1.0", optional = true }
-index-guix = { version = "1.0.0", optional = true, path = "../../index-guix" }
+index-guix = { version = "1.0.0", optional = true }
 reqwest = { version = "0.11.22", features = ["blocking"], optional = true }
 
 [features]


### PR DESCRIPTION
fixes #690

Checklist:

* [x] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
