### PR TITLE
Make geiger optional dependency

### DIFF
--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- next-url -->
 ## [Unreleased](https://github.com/crev-dev/cargo-crev/compare/v0.26.0...HEAD) - ReleaseDate
 
+- `geiger` dependency is optional (build with `--features=geiger` to enable)
+
 ## [0.26.0](https://github.com/crev-dev/cargo-crev/compare/v0.25.11...v0.26.0) - 2024-11-07
 
 - Fixed handling of the `--diff` flag.

--- a/cargo-crev/Cargo.toml
+++ b/cargo-crev/Cargo.toml
@@ -38,7 +38,7 @@ crossbeam = "0.8.2"
 chrono.workspace = true
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
 fnv = "1.0.7"
-geiger = "0.4.12"
+geiger = { version = "0.4.12", optional = true }
 itertools.workspace = true
 lazy_static = "1.4.0"
 petgraph = "0.7"
@@ -64,6 +64,7 @@ quote = "1.0.33"
 
 [features]
 default = ["openssl-sys/vendored"]
+geiger = ["dep:geiger"]
 
 documentation = []
 

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -685,6 +685,8 @@ pub fn iter_rs_files_in_dir(dir: &Path) -> impl Iterator<Item = Result<PathBuf>>
 // Note: this function is very slow
 #[cfg(feature = "geiger")]
 pub fn get_geiger_count(path: &Path) -> Result<u64> {
+    use resiter::flat_map::FlatMap;
+
     let mut count = 0;
     for metrics in iter_rs_files_in_dir(path)
         .flat_map_ok(|path| geiger::find::find_unsafe_in_file(&path, geiger::IncludeTests::No))


### PR DESCRIPTION
Because geiger now is beaks expected behavior with normal rust syntax,
and needed update is landing [so slowly there](https://github.com/geiger-rs/cargo-geiger/pull/518),
I'm pretty sure could be great to workaround it temporarily not fixed yet - make geiger optional.


This PR is "fixes" #735.


Checklist:

* [ ] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable


- - -

About checklist:

* `cargo +nightly fmt --all` a lot of modules are reformatted that are not related to the purpose of this PR. Maybe it's not worth it?