### PR TITLE
Add KeyChain support

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v16
         with:
           name: cargo-crev
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -48,7 +48,7 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@v16
         with:
           name: cargo-crev
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "resiter",
  "rpassword",
  "rprompt",
+ "security-framework 3.2.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/cargo-crev/CHANGELOG.md
+++ b/cargo-crev/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- next-url -->
 ## [Unreleased](https://github.com/crev-dev/cargo-crev/compare/v0.26.0...HEAD) - ReleaseDate
 
+- Added mac keychain support to safely store and retrieve passphrases
+
 ## [0.26.0](https://github.com/crev-dev/cargo-crev/compare/v0.25.11...v0.26.0) - 2024-11-07
 
 - Fixed handling of the `--diff` flag.

--- a/cargo-crev/Cargo.toml
+++ b/cargo-crev/Cargo.toml
@@ -62,6 +62,9 @@ term = "1.0"
 syn-inline-mod = "0.6.0"
 quote = "1.0.33"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "3.2.0"
+
 [features]
 default = ["openssl-sys/vendored"]
 

--- a/cargo-crev/src/creds.rs
+++ b/cargo-crev/src/creds.rs
@@ -4,6 +4,8 @@ use security_framework::os::macos::keychain::SecKeychain;
 
 const NOT_FOUND: i32 = -25300; // errSecItemNotFound
 const SERVICE: &str = "cargo-crev:id";
+/// Used to save or retrieve passphrase from KeyChain as "for any id" if we have only one id.
+pub const NO_ID: &str = "";
 
 pub fn retrieve_existing_passphrase(id: &str) -> Result<String, anyhow::Error> {
     let keychain = SecKeychain::default()?;

--- a/cargo-crev/src/creds.rs
+++ b/cargo-crev/src/creds.rs
@@ -1,0 +1,52 @@
+use std::fmt::Display;
+
+use security_framework::os::macos::keychain::SecKeychain;
+
+const NOT_FOUND: i32 = -25300; // errSecItemNotFound
+const SERVICE: &str = "cargo-crev:id";
+
+pub fn retrieve_existing_passphrase(id: &str) -> Result<String, anyhow::Error> {
+    let keychain = SecKeychain::default()?;
+    let not_found = security_framework::base::Error::from(NOT_FOUND).code();
+
+    match keychain.find_generic_password(&SERVICE, id) {
+        Ok((pass, _)) => {
+            let password = String::from_utf8(pass.as_ref().to_vec())?;
+            Ok(password)
+        }
+        Err(e) if e.code() == not_found => Err(Error::NotFound.into()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn save_new_passphrase(id: &str, password: &str) -> Result<(), anyhow::Error> {
+    let keychain = SecKeychain::default()?;
+    let not_found = security_framework::base::Error::from(NOT_FOUND).code();
+
+    match keychain.find_generic_password(&SERVICE, id) {
+        Err(e) => {
+            if e.code() == not_found {
+                keychain.add_generic_password(&SERVICE, id, password.as_bytes())?;
+            }
+        }
+        Ok((_, mut item)) => {
+            item.set_password(password.as_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    NotFound,
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NotFound => write!(f, "Credentials not found"),
+        }
+    }
+}

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -41,6 +41,9 @@ mod term;
 mod tokei;
 mod wot;
 
+#[cfg(target_os = "macos")]
+mod creds;
+
 use crate::{
     repo::Repo,
     review::{create_review_proof, list_reviews},

--- a/cargo-crev/src/term.rs
+++ b/cargo-crev/src/term.rs
@@ -127,33 +127,48 @@ impl Term {
 }
 
 pub fn read_passphrase() -> io::Result<String> {
-    if let Ok(pass) = env::var("CREV_PASSPHRASE") {
+    #[cfg(target_os = "macos")]
+    let by_keychain = crate::creds::retrieve_existing_passphrase("").ok();
+    #[cfg(not(target_os = "macos"))]
+    let by_keychain = None;
+
+    if let Some(pass) = by_keychain {
+        eprintln!("Using passphrase retrieved from KeyChain");
+        Ok(pass)
+    } else if let Ok(pass) = env::var("CREV_PASSPHRASE") {
         eprintln!("Using passphrase set in CREV_PASSPHRASE");
-        return Ok(pass);
+        Ok(pass)
     } else if let Some(cmd) = env::var_os("CREV_PASSPHRASE_CMD") {
-        return Ok(
+        Ok(
             String::from_utf8_lossy(&crev_common::run_with_shell_cmd_capture_stdout(&cmd, None)?)
                 .trim()
                 .to_owned(),
-        );
+        )
+    } else {
+        eprint!("Enter passphrase to unlock: ");
+        rpassword::read_password()
     }
-    eprint!("Enter passphrase to unlock: ");
-    rpassword::read_password()
 }
 
 pub fn read_new_passphrase() -> io::Result<String> {
-    if let Ok(pass) = env::var("CREV_PASSPHRASE") {
+    let password = if let Ok(pass) = env::var("CREV_PASSPHRASE") {
         eprintln!("Using passphrase set in CREV_PASSPHRASE");
-        return Ok(pass);
-    }
-    loop {
-        eprint!("Enter new passphrase: ");
-        let p1 = rpassword::read_password()?;
-        eprint!("Enter new passphrase again: ");
-        let p2 = rpassword::read_password()?;
-        if p1 == p2 {
-            return Ok(p1);
+        pass
+    } else {
+        'term: loop {
+            eprint!("Enter new passphrase: ");
+            let p1 = rpassword::read_password()?;
+            eprint!("Enter new passphrase again: ");
+            let p2 = rpassword::read_password()?;
+            if p1 == p2 {
+                break 'term p1;
+            }
+            eprintln!("\nPassphrases don't match, try again.");
         }
-        eprintln!("\nPassphrases don't match, try again.");
-    }
+    };
+
+    #[cfg(target_os = "macos")]
+    crate::creds::save_new_passphrase("", &password).ok();
+
+    Ok(password)
 }

--- a/cargo-crev/src/term.rs
+++ b/cargo-crev/src/term.rs
@@ -10,6 +10,7 @@ use term::{
     StderrTerminal, StdoutTerminal,
 };
 
+#[cfg(target_os = "macos")]
 use crate::creds;
 
 pub fn verification_status_color(s: VerificationStatus) -> Option<color::Color> {

--- a/cargo-crev/src/term.rs
+++ b/cargo-crev/src/term.rs
@@ -10,6 +10,8 @@ use term::{
     StderrTerminal, StdoutTerminal,
 };
 
+use crate::creds;
+
 pub fn verification_status_color(s: VerificationStatus) -> Option<color::Color> {
     use VerificationStatus::*;
     match s {
@@ -128,7 +130,7 @@ impl Term {
 
 pub fn read_passphrase() -> io::Result<String> {
     #[cfg(target_os = "macos")]
-    let by_keychain = crate::creds::retrieve_existing_passphrase("").ok();
+    let by_keychain = creds::retrieve_existing_passphrase(creds::NO_ID).ok();
     #[cfg(not(target_os = "macos"))]
     let by_keychain = None;
 
@@ -168,7 +170,7 @@ pub fn read_new_passphrase() -> io::Result<String> {
     };
 
     #[cfg(target_os = "macos")]
-    crate::creds::save_new_passphrase("", &password).ok();
+    creds::save_new_passphrase(creds::NO_ID, &password).ok();
 
     Ok(password)
 }


### PR DESCRIPTION
This PR adds mac keychain basic support - without unlocked session, just ordinary get/set.

It needed to mode safely (and friendly!) store and retrieve passphrases then from env or shell.

Checklist:

* [ ] `cargo +nightly fmt --all`
* [x] Modify `CHANGELOG.md` if applicable
