### PR TITLE
chore: Fix docs CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 LTS runner has been removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

Checklist:

* [ ] `cargo +nightly fmt --all`
* [ ] Modify `CHANGELOG.md` if applicable
