### PR TITLE
chore: optimize crypto crates in dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,13 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_yaml = "0.9.25"
 thiserror = "2.0"
+
+# Crypto crates are unusably slow without optimizations
+[profile.dev.package]
+blake2 = { opt-level = 2 }
+ed25519-dalek = { opt-level = 2 }
+curve25519-dalek = { opt-level = 2 }
+sha2 = { opt-level = 2 }
+rust-argon2 = { opt-level = 2 }
+blake2b_simd = { opt-level = 2 }
+constant_time_eq = { opt-level = 2 }


### PR DESCRIPTION
Build blake2, ed25519-dalek, curve25519-dalek, and sha2 with opt-level=2 in debug builds as they are unusably slow otherwise.
