### PR TITLE
feat(crate): add `cargo crev crate digest` subcommand

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -612,6 +612,9 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                 }
             }
             opts::Crate::Dir(args) => show_dir(&args.common.crate_.auto_unrelated()?)?,
+            opts::Crate::Digest(args) => {
+                shared::show_crate_digest(&args.common.crate_.auto_unrelated()?)?
+            }
 
             opts::Crate::Review(args) => crate_review(&args, TrustProofType::Trust)?,
             opts::Crate::Unreview(args) => crate_review(&args, TrustProofType::Untrust)?,

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -570,6 +570,12 @@ pub struct CrateDir {
 }
 
 #[derive(Debug, StructOpt, Clone)]
+pub struct CrateDigest {
+    #[structopt(flatten)]
+    pub common: ReviewCrateSelector,
+}
+
+#[derive(Debug, StructOpt, Clone)]
 pub enum RepoQuery {
     /// Query reviews
     #[structopt(name = "review")]
@@ -806,6 +812,13 @@ pub enum Crate {
     /// Display the path of the source code directory of a crate
     #[structopt(name = "dir")]
     Dir(CrateDir),
+
+    /// Print the recursive digest (blake2b, base64url) of a crate's source
+    ///
+    /// Useful for filling in the `digest:` field of an unsigned review
+    /// prepared outside of `cargo crev review` (e.g. by an agent).
+    #[structopt(name = "digest")]
+    Digest(CrateDigest),
 
     /// Verify dependencies
     #[structopt(name = "verify")]

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -562,6 +562,19 @@ pub fn show_dir(sel: &opts::CrateSelector) -> Result<()> {
     Ok(())
 }
 
+pub fn show_crate_digest(sel: &opts::CrateSelector) -> Result<()> {
+    let repo = Repo::auto_open_cwd_default()?;
+
+    sel.ensure_name_given()?;
+    let crate_id = repo.find_pkgid_by_crate_selector(sel)?;
+    let crate_ = repo.get_crate(&crate_id)?;
+    let digest =
+        crev_lib::get_recursive_digest_for_dir(crate_.root(), &cargo_min_ignore_list())?;
+    println!("{digest}");
+
+    Ok(())
+}
+
 pub fn list_advisories(crate_: &opts::CrateSelector) -> Result<()> {
     for review in find_advisories(crate_)? {
         println!("---\n{review}");


### PR DESCRIPTION
Print the recursive blake2b digest (base64url) of a crate's source directory.

Mirrors `cargo crev crate dir` in selector handling.