### PR TITLE
feat(verify): add --force-print-header flag

### DIFF
--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -333,7 +333,7 @@ pub fn verify_deps(crate_: CrateSelector, args: CrateVerify) -> Result<CommandEx
     });
 
     // print header, only after `scanner` had a chance to download everything
-    if term.is_interactive() {
+    if term.is_interactive() || args.force_print_header {
         print_term::print_header(&mut term, &args.columns, column_widths)?;
     }
 

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -434,6 +434,11 @@ pub struct CrateVerify {
     #[structopt(long = "recursive")]
     /// Calculate recursive metrics for your packages
     pub recursive: bool,
+
+    #[structopt(long = "force-print-header")]
+    /// Always print the column header, even when stdout is not a TTY (useful
+    /// for capturing the output into a file for later processing).
+    pub force_print_header: bool,
 }
 
 #[derive(Debug, StructOpt, Clone)]


### PR DESCRIPTION
Always print the column header when set, even when stdout is not a TTY. Makes it easy to capture `cargo crev verify --show-all` output into a file for later processing (e.g. by agents picking review candidates).
