### PR TITLE
chore: introduce `cargo crev ai` commands 

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -791,6 +791,16 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
         opts::Command::Verify(opts) => {
             return deps::verify_deps(opts.crate_, opts.opts);
         }
+        opts::Command::Ai(args) => match args {
+            opts::Ai::Skill(skill) => match skill {
+                opts::AiSkill::Review => {
+                    print!(
+                        "{}",
+                        include_str!("../../skills/cargo-crev-review/SKILL.md")
+                    );
+                }
+            },
+        },
     }
 
     Ok(CommandExitStatus::Success)

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -800,7 +800,74 @@ fn run_command(command: opts::Command) -> Result<CommandExitStatus> {
                     );
                 }
             },
+            opts::Ai::ReviewLoop(args) => {
+                return ai_review_loop(&args);
+            }
         },
+    }
+
+    Ok(CommandExitStatus::Success)
+}
+
+fn ai_review_loop(args: &opts::AiReviewLoop) -> Result<CommandExitStatus> {
+    if args.agent == opts::AiAgent::Claude && std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        eprintln!("Warning: ANTHROPIC_API_KEY is set. Claude Code will use direct API billing.");
+        if std::env::var("CARGO_CREV_ANTHROPIC_API_KEY_ENABLE").as_deref() != Ok("true") {
+            bail!(
+                "Set CARGO_CREV_ANTHROPIC_API_KEY_ENABLE=true to confirm you want to use \
+                 direct API billing. This guard protects against accidental API usage."
+            );
+        }
+    }
+
+    eprintln!("Signing script: target/crev/sign-all.sh");
+
+    for i in 1..=args.iterations {
+        eprintln!("=== Review iteration {i}/{} ===", args.iterations);
+
+        let prompt = r#"You are tasked with reviewing a single Rust dependency using the cargo-crev review skill.
+
+If you don't already have access to the `cargo-crev-review` skill, obtain it by running:
+
+```sh
+cargo crev ai skill review
+```
+
+Save the output as a local skill and use it.
+
+Then, follow the skill instructions to:
+
+1. Review a single unreviewed dependency (pick one that hasn't been reviewed yet,
+   checking `target/crev/reviews/` for already-reviewed crates to avoid duplicates).
+2. Write the review report and unsigned proof as described in the skill.
+3. Append the signing command to `target/crev/sign-all.sh` (create it if it doesn't exist,
+   with `#!/usr/bin/env bash` and `set -euo pipefail` header).
+
+Important:
+- Review exactly ONE crate per invocation.
+- Before picking a crate, check `target/crev/sign-all.sh` and `target/crev/reviews/` for
+  crates that were already reviewed in previous iterations. Do NOT review them again.
+- Do NOT sign the proof — only prepare the unsigned proof and append the signing command.
+- Do NOT run `cargo crev publish`.
+- Your entire output must be a single paragraph containing: the crate name and version,
+  the review parameters (rating, thoroughness, understanding), and a brief result summary.
+  No other output.
+"#;
+
+        let status = std::process::Command::new("claude")
+            .arg("-p")
+            .arg(prompt)
+            .status()
+            .map_err(|e| {
+                format_err!("Failed to launch 'claude' CLI. Is Claude Code installed? {e}")
+            })?;
+
+        if !status.success() {
+            eprintln!(
+                "Warning: claude exited with status {} on iteration {i}",
+                status.code().unwrap_or(-1)
+            );
+        }
     }
 
     Ok(CommandExitStatus::Success)

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -1068,6 +1068,24 @@ pub enum Command {
     /// Shortcut for `crate verify`
     #[structopt(name = "verify")]
     Verify(CrateVerifyFull),
+
+    /// AI-related commands
+    #[structopt(name = "ai")]
+    Ai(Ai),
+}
+
+#[derive(Debug, StructOpt, Clone)]
+pub enum Ai {
+    /// AI skill management
+    #[structopt(name = "skill")]
+    Skill(AiSkill),
+}
+
+#[derive(Debug, StructOpt, Clone)]
+pub enum AiSkill {
+    /// Print the AI review skill content
+    #[structopt(name = "review")]
+    Review,
 }
 
 /// Cargo will pass the name of the `cargo-<tool>`

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -1079,6 +1079,45 @@ pub enum Ai {
     /// AI skill management
     #[structopt(name = "skill")]
     Skill(AiSkill),
+
+    /// Run an AI agent in a loop to review dependencies
+    #[structopt(name = "review-loop")]
+    ReviewLoop(AiReviewLoop),
+}
+
+#[derive(Debug, StructOpt, Clone)]
+pub struct AiReviewLoop {
+    /// Number of review iterations to run
+    #[structopt(long, default_value = "1")]
+    pub iterations: u32,
+
+    /// AI agent to use
+    #[structopt(long, default_value = "claude")]
+    pub agent: AiAgent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AiAgent {
+    Claude,
+}
+
+impl std::str::FromStr for AiAgent {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "claude" => Ok(Self::Claude),
+            other => Err(format!("unsupported agent: '{other}'. Supported: claude")),
+        }
+    }
+}
+
+impl std::fmt::Display for AiAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Claude => write!(f, "claude"),
+        }
+    }
 }
 
 #[derive(Debug, StructOpt, Clone)]


### PR DESCRIPTION
`cargo crev ai skill review` for an easy built-in way to get the review skill, and `cargo crev ai review-loop` for running a higher-level loop to keep reviewing dependencies.