### PR TITLE
feat(cli): add passthrough agent args to review-loop

### DIFF
--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -854,13 +854,11 @@ Important:
   No other output.
 "#;
 
-        let status = std::process::Command::new("claude")
-            .arg("-p")
-            .arg(prompt)
-            .status()
-            .map_err(|e| {
-                format_err!("Failed to launch 'claude' CLI. Is Claude Code installed? {e}")
-            })?;
+        let mut cmd = std::process::Command::new("claude");
+        cmd.arg("-p").arg(prompt).args(&args.agent_args);
+        let status = cmd.status().map_err(|e| {
+            format_err!("Failed to launch 'claude' CLI. Is Claude Code installed? {e}")
+        })?;
 
         if !status.success() {
             eprintln!(

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -1094,6 +1094,10 @@ pub struct AiReviewLoop {
     /// AI agent to use
     #[structopt(long, default_value = "claude")]
     pub agent: AiAgent,
+
+    /// Additional arguments to pass to the AI agent
+    #[structopt(last = true)]
+    pub agent_args: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Replace --max-budget-usd with generic -- <agent-args>... passthrough, allowing users to pass any arguments to the underlying AI agent CLI.
