### PR TITLE
 ci: replace unpinned cargo fmt with nix treefmt check in GitHub CI 

### DIFF
--- a/.config/selfci/ci.sh
+++ b/.config/selfci/ci.sh
@@ -3,7 +3,7 @@ set -eou pipefail
 
 function job_lint() {
   selfci step start "treefmt"
-  if ! treefmt --ci ; then
+  if ! nix build -L .#ci.fmt ; then
     selfci step fail
   fi
 }
@@ -40,8 +40,7 @@ case "$SELFCI_JOB_NAME" in
     job_cargo
     ;;
   lint)
-    export -f job_lint
-    nix develop -c bash -c "job_lint"
+    job_lint
     ;;
   *)
     echo "Unknown job: $SELFCI_JOB_NAME"

--- a/.config/selfci/ci.sh
+++ b/.config/selfci/ci.sh
@@ -2,6 +2,11 @@
 set -eou pipefail
 
 function job_lint() {
+  selfci step start "cargo fmt"
+  if ! nix build -L .#ci.cargoFmt ; then
+    selfci step fail
+  fi
+
   selfci step start "treefmt"
   if ! nix build -L .#ci.fmt ; then
     selfci step fail

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -27,6 +27,12 @@ jobs:
           name: cargo-crev
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - name: Check Rust formatting
+        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#ci.cargoFmt
+
+      - name: Check all formatting
+        run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#treefmt
+
       - name: Build workspace
         run: nix build -L --extra-experimental-features nix-command --extra-experimental-features flakes .#ci.workspace
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -3,13 +3,10 @@ name: "CI (nix)"
 env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  pull_request:
   push:
     branches: [ "main", "master", "devel" ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,25 +129,6 @@ jobs:
       if: matrix.target != ''
       run: ${{ env.CARGO }} test --verbose --workspace ${{ env.TARGET_FLAGS }}
 
-  rustfmt:
-    name: rustfmt
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        profile: minimal
-        components: rustfmt
-    - name: Check formatting
-      run: |
-        rustfmt --version
-        cargo fmt --all -- --check
-
   docs:
     name: docs
     runs-on: ubuntu-24.04

--- a/cargo-crev/rustfmt.toml
+++ b/cargo-crev/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2018"
-# imports_granularity="Crate"
-

--- a/cargo-crev/src/crates_io.rs
+++ b/cargo-crev/src/crates_io.rs
@@ -1,11 +1,13 @@
-use crate::{deps::DownloadsStats, prelude::*};
-use serde::{Serialize, de::DeserializeOwned};
-use std::{
-    fs,
-    io::Read,
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::deps::DownloadsStats;
+use crate::prelude::*;
 
 pub struct Client {
     client: crates_io_api::SyncClient,

--- a/cargo-crev/src/creds.rs
+++ b/cargo-crev/src/creds.rs
@@ -4,7 +4,8 @@ use security_framework::os::macos::keychain::SecKeychain;
 
 const NOT_FOUND: i32 = -25300; // errSecItemNotFound
 const SERVICE: &str = "cargo-crev:id";
-/// Used to save or retrieve passphrase from KeyChain as "for any id" if we have only one id.
+/// Used to save or retrieve passphrase from KeyChain as "for any id" if we have
+/// only one id.
 pub const NO_ID: &str = "";
 
 pub fn retrieve_existing_passphrase(id: &str) -> Result<String, anyhow::Error> {

--- a/cargo-crev/src/deps.rs
+++ b/cargo-crev/src/deps.rs
@@ -1,17 +1,20 @@
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::io::Write as _;
+use std::ops::Add;
+use std::path::PathBuf;
+
 use ::term::color::YELLOW;
+use cargo::core::PackageId;
 use crev_data::{Digest, PublicId, Version, proof, review};
 use crev_lib::VerificationStatus;
 use crev_wot::TrustSet;
-use std::{io, io::Write as _, path::PathBuf};
-
-use crate::{opts::*, prelude::*, shared::CommandExitStatus, term};
-use cargo::core::PackageId;
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Add,
-};
 
 use self::scan::RequiredDetails;
+use crate::opts::*;
+use crate::prelude::*;
+use crate::shared::CommandExitStatus;
+use crate::term;
 
 mod print_term;
 pub mod scan;

--- a/cargo-crev/src/deps/print_term.rs
+++ b/cargo-crev/src/deps/print_term.rs
@@ -1,9 +1,11 @@
 // Functions related to writing dependencies in the standard
 // terminal (not in the context of a real terminal application)
 
+use std::io::Write;
+use std::{io, write, writeln};
+
 use super::*;
 use crate::term::{self, Term};
-use std::{io, io::Write, write, writeln};
 
 const CRATE_VERIFY_CRATE_COLUMN_TITLE: &str = "crate";
 const CRATE_VERIFY_VERSION_COLUMN_TITLE: &str = "version";
@@ -41,11 +43,7 @@ impl VerifyOutputColumnWidths {
         } else {
             version
         };
-        let latest_trusted = if human {
-            TRUNCATED_LATEST_T_WIDTH
-        } else {
-            12
-        };
+        let latest_trusted = if human { TRUNCATED_LATEST_T_WIDTH } else { 12 };
 
         Self {
             name,

--- a/cargo-crev/src/deps/scan.rs
+++ b/cargo-crev/src/deps/scan.rs
@@ -1,33 +1,30 @@
-use crate::{
-    crates_io,
-    deps::{
-        AccumulativeCrateDetails, CountWithTotal, CrateDetails, CrateInfo, CrateStats, OwnerSetSet,
-    },
-    opts::{CargoOpts, CrateSelector, CrateVerify},
-    prelude::*,
-    repo::Repo,
-    shared::{
-        cargo_full_ignore_list, cargo_min_ignore_list, get_crate_digest_mismatches,
-        get_geiger_count, read_known_owners_list,
-    },
-};
+use std::collections::{HashMap, HashSet};
+use std::default::Default;
+use std::path::PathBuf;
+use std::sync::atomic::{self, AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::Duration;
+
 use cargo::core::PackageId;
 use crev_data::SOURCE_CRATES_IO;
 use crev_data::proof::{self, CommonOps};
 use crev_lib::{self, VerificationStatus};
 use crev_wot::{self, ProofDB, TrustSet};
-use crossbeam::{self, channel::unbounded};
+use crossbeam::channel::unbounded;
+use crossbeam::{self};
 use log::debug;
-use std::{
-    collections::{HashMap, HashSet},
-    default::Default,
-    path::PathBuf,
-    sync::{
-        Arc, Mutex,
-        atomic::{self, AtomicBool, Ordering},
-    },
-    thread::sleep,
-    time::Duration,
+
+use crate::crates_io;
+use crate::deps::{
+    AccumulativeCrateDetails, CountWithTotal, CrateDetails, CrateInfo, CrateStats, OwnerSetSet,
+};
+use crate::opts::{CargoOpts, CrateSelector, CrateVerify};
+use crate::prelude::*;
+use crate::repo::Repo;
+use crate::shared::{
+    cargo_full_ignore_list, cargo_min_ignore_list, get_crate_digest_mismatches, get_geiger_count,
+    read_known_owners_list,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -76,9 +73,10 @@ pub struct Scanner {
     crate_details_by_id: Arc<Mutex<HashMap<PackageId, CrateDetails>>>,
 }
 
-// Something in (presumably) in the C bindings we're using is unsound and will SIGSEGV
-// if the threads are still running while the main thread terminated. To prevent that
-// we wrap all handles in this struct that will `join` them on `drop`.
+// Something in (presumably) in the C bindings we're using is unsound and will
+// SIGSEGV if the threads are still running while the main thread terminated. To
+// prevent that we wrap all handles in this struct that will `join` them on
+// `drop`.
 pub struct ScannerHandle {
     threads: Vec<std::thread::JoinHandle<()>>,
     canceled_flag: Arc<AtomicBool>,

--- a/cargo-crev/src/doc/mod.rs
+++ b/cargo-crev/src/doc/mod.rs
@@ -1,7 +1,8 @@
 /// # User documentation
 ///
-/// New users are advised to start by reading the [Getting Started Guide](`self::user::getting_started`)
-/// and [Glossary](`self::user::glossary`) modules.
+/// New users are advised to start by reading the [Getting Started
+/// Guide](`self::user::getting_started`) and [Glossary](`self::user::glossary`)
+/// modules.
 ///
 /// Please be aware that all user documentation is
 /// a continuous work in progress, and can be incorrect

--- a/cargo-crev/src/dyn_proof.rs
+++ b/cargo-crev/src/dyn_proof.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 
 use anyhow::{Result, bail};
-use crev_data::{
-    PublicId, UnlockedId,
-    proof::{self, CommonOps, ContentExt},
-};
+use crev_data::proof::{self, CommonOps, ContentExt};
+use crev_data::{PublicId, UnlockedId};
 
 pub fn parse_dyn_content(proof: &proof::Proof) -> Result<Box<dyn DynContent>> {
     Ok(match proof.kind() {

--- a/cargo-crev/src/edit.rs
+++ b/cargo-crev/src/edit.rs
@@ -1,12 +1,13 @@
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+use std::{env, ffi};
+
 use anyhow::{Result, bail};
 use crev_common::{CancelledError, run_with_shell_cmd};
-use crev_data::{proof, proof::content::ContentExt};
-use crev_lib::{local::Local, util::get_documentation_for};
-use std::{
-    env, ffi,
-    fmt::Write,
-    path::{Path, PathBuf},
-};
+use crev_data::proof;
+use crev_data::proof::content::ContentExt;
+use crev_lib::local::Local;
+use crev_lib::util::get_documentation_for;
 
 fn get_git_default_editor() -> Result<String> {
     let cfg = git2::Config::open_default()?;
@@ -25,7 +26,8 @@ fn get_editor_to_use() -> Result<ffi::OsString> {
     })
 }
 
-/// Returns the edited string, and bool indicating if the file was ever written to/ (saved).
+/// Returns the edited string, and bool indicating if the file was ever written
+/// to/ (saved).
 fn edit_text_iteractively_raw(text: &str) -> Result<(String, bool)> {
     let dir = tempfile::tempdir()?;
     let file_path = dir.path().join("crev.review.yaml");

--- a/cargo-crev/src/info.rs
+++ b/cargo-crev/src/info.rs
@@ -1,15 +1,14 @@
-use crate::{
-    Repo,
-    deps::{
-        AccumulativeCrateDetails,
-        scan::{self, RequiredDetails},
-    },
-    opts::{CrateSelector, CrateVerify, CrateVerifyCommon, WotOpts},
-};
+use std::collections::HashSet;
+use std::io;
+
 use anyhow::{Result, bail};
 use crev_data::proof;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, io};
+
+use crate::Repo;
+use crate::deps::AccumulativeCrateDetails;
+use crate::deps::scan::{self, RequiredDetails};
+use crate::opts::{CrateSelector, CrateVerify, CrateVerifyCommon, WotOpts};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/cargo-crev/src/main.rs
+++ b/cargo-crev/src/main.rs
@@ -1,5 +1,4 @@
 //! `cargo-crev` - `crev` ecosystem fronted for Rusti (`cargo` integration)
-//!
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::redundant_closure_for_method_calls)]
 #![type_length_limit = "1932159"]
@@ -7,21 +6,23 @@
     feature = "documentation",
     doc = "See [user documentation module](./doc/user/index.html)."
 )]
-use crate::prelude::*;
-use crev_data::{SOURCE_CRATES_IO, UnlockedId, proof::ContentExt};
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::io::{self, BufRead, Write as _};
+use std::panic;
+use std::path::PathBuf;
+
+use crev_data::proof::ContentExt;
+use crev_data::{SOURCE_CRATES_IO, UnlockedId};
 use crev_lib::id::LockedId;
-use crev_lib::{self, local::Local};
+use crev_lib::local::Local;
+use crev_lib::{self};
 use log::info;
 use opts::ReviewCrateSelector;
-use std::{
-    collections::{HashMap, HashSet},
-    ffi::OsString,
-    fmt::Write as _,
-    io::{self, BufRead, Write as _},
-    panic,
-    path::PathBuf,
-};
 use structopt::StructOpt;
+
+use crate::prelude::*;
 
 #[cfg(feature = "documentation")]
 /// Documentation
@@ -44,15 +45,14 @@ mod wot;
 #[cfg(target_os = "macos")]
 mod creds;
 
-use crate::{
-    repo::Repo,
-    review::{create_review_proof, list_reviews},
-    shared::*,
-};
 use crev_data::{Id, TrustLevel, proof};
 use crev_lib::{TrustProofType, Warning};
 use crev_wot::{PkgVersionReviewId, ProofDB, TrustSet, UrlOfId};
 use log::debug;
+
+use crate::repo::Repo;
+use crate::review::{create_review_proof, list_reviews};
+use crate::shared::*;
 
 /// Additional functions to extend `Local` by behaviors
 /// that are `cargo-crev` specific, like printing
@@ -827,7 +827,8 @@ fn ai_review_loop(args: &opts::AiReviewLoop) -> Result<CommandExitStatus> {
 
     eprintln!("Signing script: target/crev/sign-all.sh");
 
-    // Preparation iteration: update WoT, capture verify output, clean up sign-all.sh
+    // Preparation iteration: update WoT, capture verify output, clean up
+    // sign-all.sh
     eprintln!("=== Preparation ===");
     {
         let prep_prompt = include_str!(concat!(
@@ -955,7 +956,8 @@ fn generate_new_id_interactively(url: Option<&str>, use_https_push: bool) -> Res
             }
         }
 
-        // if an old one couldn't be reconfigured automatically, help how to do it manually
+        // if an old one couldn't be reconfigured automatically, help how to do it
+        // manually
         if let Some(example) = existing_usable.first() {
             if local
                 .get_current_userid()

--- a/cargo-crev/src/opts.rs
+++ b/cargo-crev/src/opts.rs
@@ -1,6 +1,8 @@
+use std::ffi::OsString;
+use std::path::PathBuf;
+
 use anyhow::{Result, bail};
 use crev_data::{Level, Version};
-use std::{ffi::OsString, path::PathBuf};
 use structopt::StructOpt;
 use term::color;
 
@@ -135,13 +137,15 @@ impl CargoOpts {
 #[derive(Debug, StructOpt, Clone)]
 pub struct IdNew {
     #[structopt(long = "url")]
-    /// Publicly-visible HTTPS URL of a git repository to be associated with the new Id
+    /// Publicly-visible HTTPS URL of a git repository to be associated with the
+    /// new Id
     pub url: Option<String>,
     #[structopt(long = "github-username")]
     /// Github username (instead of --url)
     pub github_username: Option<String>,
     #[structopt(long = "https-push")]
-    /// Use public HTTP URL for both pulling and pushing. Otherwise SSH is used for push
+    /// Use public HTTP URL for both pulling and pushing. Otherwise SSH is used
+    /// for push
     pub use_https_push: bool,
 }
 
@@ -159,22 +163,28 @@ pub struct TrustDistanceParams {
     pub direct: bool,
 
     #[structopt(long = "depth", default_value = "20")]
-    /// [trust-graph-traversal] Maximum allowed distance from the root identity when traversing trust graph
+    /// [trust-graph-traversal] Maximum allowed distance from the root identity
+    /// when traversing trust graph
     pub depth: u64,
 
-    /// [trust-graph-traversal] Cost of traversing trust graph edge of high trust level
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of high
+    /// trust level
     #[structopt(long = "high-cost", default_value = "0")]
     pub high_cost: u64,
-    /// [trust-graph-traversal] Cost of traversing trust graph edge of medium trust level
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of medium
+    /// trust level
     #[structopt(long = "medium-cost", default_value = "1")]
     pub medium_cost: u64,
-    /// [trust-graph-traversal] Cost of traversing trust graph edge of low trust level
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of low trust
+    /// level
     #[structopt(long = "low-cost", default_value = "5")]
     pub low_cost: u64,
-    /// [trust-graph-traversal] Cost of traversing trust graph edge of none trust level
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of none
+    /// trust level
     #[structopt(long = "none-cost", default_value = "21")]
     pub none_cost: u64,
-    /// [trust-graph-traversal] Cost of traversing trust graph edge of distrust trust level
+    /// [trust-graph-traversal] Cost of traversing trust graph edge of distrust
+    /// trust level
     #[structopt(long = "distrust-cost", default_value = "21")]
     pub distrust_cost: u64,
 }
@@ -282,7 +292,8 @@ pub struct WotOpts {
     pub trust_params: TrustDistanceParams,
 
     #[structopt(long = "for-id")]
-    /// Root identity to calculate the Web of Trust for [default: current user id]
+    /// Root identity to calculate the Web of Trust for [default: current user
+    /// id]
     pub for_id: Option<String>,
 }
 
@@ -446,7 +457,8 @@ pub struct CrateVerify {
 
     #[structopt(long = "human-metrics")]
     /// Human-friendly output: truncate long columns, use M suffix for large
-    /// download counts. Set to false for machine-parseable output [default: true]
+    /// download counts. Set to false for machine-parseable output [default:
+    /// true]
     pub human_metrics: Option<bool>,
 }
 
@@ -477,7 +489,8 @@ pub struct TrustUrls {
     pub public_ids_or_urls: Vec<String>,
 
     /// Shortcut for setting trust level without editing.
-    /// Possible values are: "none" or "untrust", "low", "medium", "high" and "distrust".
+    /// Possible values are: "none" or "untrust", "low", "medium", "high" and
+    /// "distrust".
     #[structopt(long = "level")]
     pub level: Option<crev_data::TrustLevel>,
 
@@ -635,7 +648,8 @@ pub struct ReviewCrateSelector {
 
 #[derive(Debug, StructOpt, Clone)]
 pub struct CrateOpen {
-    /// Shell command to execute with crate directory as an argument. Eg. "code --wait -n" for VSCode
+    /// Shell command to execute with crate directory as an argument. Eg. "code
+    /// --wait -n" for VSCode
     #[structopt(long = "cmd")]
     pub cmd: Option<String>,
 
@@ -1056,7 +1070,8 @@ pub enum Command {
 
     /// Shortcut for `crate open`
     ///
-    /// Crev will remember the last crate you've opened and default `crev review` to the same crate.
+    /// Crev will remember the last crate you've opened and default `crev
+    /// review` to the same crate.
     #[structopt(name = "open")]
     Open(CrateOpen),
 
@@ -1155,7 +1170,8 @@ User documentation: https://docs.rs/crate/cargo-crev
 
 #[derive(Debug, StructOpt, Clone)]
 #[structopt(about = "Distributed code review system")]
-// without this the name will be `cargo-crev-crev` because the `crev` main command will be automatically appended
+// without this the name will be `cargo-crev-crev` because the `crev` main command will be
+// automatically appended
 #[structopt(bin_name = "cargo")]
 #[structopt(global_setting = structopt::clap::AppSettings::ColoredHelp)]
 #[structopt(global_setting = structopt::clap::AppSettings::InferSubcommands)]

--- a/cargo-crev/src/repo.rs
+++ b/cargo-crev/src/repo.rs
@@ -1,33 +1,29 @@
-use crate::{opts, opts::CrateSelector};
+use std::collections::hash_map::Entry;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::env;
+use std::path::PathBuf;
+use std::str::{self, FromStr};
+
 use anyhow::format_err;
-use cargo::GlobalContext;
+use cargo::core::dependency::{DepKind, Dependency};
+use cargo::core::manifest::ManifestMetadata;
+use cargo::core::package::PackageSet;
+use cargo::core::registry::PackageRegistry;
+use cargo::core::resolver::{CliFeatures, HasDevUnits};
+use cargo::core::{Package, PackageId, Resolve, SourceId, Workspace};
 use cargo::sources::SourceConfigMap;
 use cargo::sources::source::{QueryKind, Source, SourceMap};
-use cargo::{
-    core::{
-        Package, PackageId, Resolve, SourceId, Workspace,
-        dependency::{DepKind, Dependency},
-        manifest::ManifestMetadata,
-        package::PackageSet,
-        registry::PackageRegistry,
-        resolver::{CliFeatures, HasDevUnits},
-    },
-    ops,
-    util::{
-        CargoResult, Rustc, cache_lock::CacheLockMode, context::ConfigValue,
-        important_paths::find_root_manifest_for_wd,
-    },
-};
+use cargo::util::cache_lock::CacheLockMode;
+use cargo::util::context::ConfigValue;
+use cargo::util::important_paths::find_root_manifest_for_wd;
+use cargo::util::{CargoResult, Rustc};
+use cargo::{GlobalContext, ops};
 use cargo_platform::Cfg;
 use petgraph::graph::NodeIndex;
-use std::{
-    collections::{BTreeSet, HashMap, HashSet, hash_map::Entry},
-    env,
-    path::PathBuf,
-    str::{self, FromStr},
-};
 
-use crate::{crates_io, prelude::*};
+use crate::opts::CrateSelector;
+use crate::prelude::*;
+use crate::{crates_io, opts};
 
 #[derive(Debug)]
 struct Node {
@@ -190,8 +186,9 @@ fn build_graph<'a>(
                 .filter(|d| d.matches_ignoring_source(raw_dep_id))
                 .filter(|d| {
                     let is_local = !d.source_id().is_registry();
-                    // Dev/build dependencies can lead to circular dependencies (in combination with normal deps),
-                    // so ignore dev deps on local crates, as it's not helpful anyway
+                    // Dev/build dependencies can lead to circular dependencies (in combination with
+                    // normal deps), so ignore dev deps on local crates, as it's
+                    // not helpful anyway
                     d.kind() == DepKind::Normal || (dev_dependencies && !is_local)
                 })
                 .filter(|d| {
@@ -224,7 +221,8 @@ fn build_graph<'a>(
     Ok(graph)
 }
 
-/// Modifies the given config so that directory source replacements are removed, and references to them as well.
+/// Modifies the given config so that directory source replacements are removed,
+/// and references to them as well.
 ///
 /// - For information on directory sources, [see here](https://doc.rust-lang.org/cargo/reference/source-replacement.html#directory-sources)
 /// - For information on source replacement, [see here](https://doc.rust-lang.org/cargo/reference/config.html#source)
@@ -232,10 +230,11 @@ fn prune_directory_source_replacements(
     config: &mut HashMap<String, ConfigValue>,
 ) -> CargoResult<()> {
     if let Some(ConfigValue::Table(source_config, _)) = config.get_mut("source") {
-        // To do the pruning, first, generate a graph of registry sources, where the node are the sources, and there is an edge if a source
-        //  defines that it is replaced with another source.
-        // Then, find the directory sources, and traverse the graph in reverse to find all the sources that are directory sources, or reference them
-        //  directly or indirectly.
+        // To do the pruning, first, generate a graph of registry sources, where the
+        // node are the sources, and there is an edge if a source  defines that
+        // it is replaced with another source. Then, find the directory sources,
+        // and traverse the graph in reverse to find all the sources that are directory
+        // sources, or reference them  directly or indirectly.
         // Then, the found sources can be removed from the config.
         let mut source_graph = petgraph::Graph::<String, ()>::new();
         let nodes = source_config
@@ -326,8 +325,9 @@ impl Repo {
 
         // how it used to be; can't find it anywhere anymore
         // let features_set =
-        //     Method::split_features(&[cargo_opts.features.clone().unwrap_or_else(String::new)]);
-        // let features_list = features_set.iter().map(|i| i.as_str().to_owned()).collect();
+        //     Method::split_features(&[cargo_opts.features.clone().
+        // unwrap_or_else(String::new)]); let features_list =
+        // features_set.iter().map(|i| i.as_str().to_owned()).collect();
         let features_list = cargo_opts
             .features
             .clone()
@@ -662,24 +662,27 @@ impl Repo {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use cargo::util::context::Definition;
+
+    use super::*;
 
     #[test]
     fn test_prune_directory_source_replacement() {
         // Test that:
         // {
-        //     "source": {"crates-io": {"replace-with": my-vendor-source (from --config cli option)},
-        //                "another-source": {"registry": path/to/registry (from --config cli option)},
-        //                "my-vendor-source": {"directory": vendor (from --config cli option)}},
+        //     "source": {"crates-io": {"replace-with": my-vendor-source (from --config
+        // cli option)},                "another-source": {"registry":
+        // path/to/registry (from --config cli option)},
+        // "my-vendor-source": {"directory": vendor (from --config cli option)}},
         // }
         // becomes:
         // {
-        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)}},
-        // }
+        //     "source": {"another-source": {"registry": path/to/registry (from --config
+        // cli option)}}, }
         //
-        // the "my-vendor-source" should get removed because it's a directory source replacement,
-        // and "crates-io" should get removed because it referenced the removed "my-vendor-source"
+        // the "my-vendor-source" should get removed because it's a directory source
+        // replacement, and "crates-io" should get removed because it referenced
+        // the removed "my-vendor-source"
         let crates_io_source_replacement = ConfigValue::Table(
             [(
                 "replace-with".into(),
@@ -747,19 +750,21 @@ mod tests {
     fn test_prune_directory_source_replacement_nested() {
         // Test that:
         // {
-        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)},
-        //                "nested-vendor-source": {"directory": vendor (from --config cli option)},
-        //                "my-vendor-source": {"replace-with": nested-vendor-source (from --config cli option)},
-        //                "crates-io": {"replace-with": my-vendor-source (from --config cli option)}},
-        // }
+        //     "source": {"another-source": {"registry": path/to/registry (from --config
+        // cli option)},                "nested-vendor-source": {"directory":
+        // vendor (from --config cli option)},
+        // "my-vendor-source": {"replace-with": nested-vendor-source (from --config cli
+        // option)},                "crates-io": {"replace-with":
+        // my-vendor-source (from --config cli option)}}, }
         // becomes:
         // {
-        //     "source": {"another-source": {"registry": path/to/registry (from --config cli option)}},
-        // }
+        //     "source": {"another-source": {"registry": path/to/registry (from --config
+        // cli option)}}, }
         //
-        // the "nested-vendor-source" should get removed because it's a directory source replacement,
-        // and "my-vendor-source" should get removed because it referenced the removed "nested-vendor-source"
-        // and "crates-io" should get removed because it referenced the removed "my-vendor-source"
+        // the "nested-vendor-source" should get removed because it's a directory source
+        // replacement, and "my-vendor-source" should get removed because it
+        // referenced the removed "nested-vendor-source" and "crates-io" should
+        // get removed because it referenced the removed "my-vendor-source"
         let crates_io_source_replacement = ConfigValue::Table(
             [(
                 "replace-with".into(),

--- a/cargo-crev/src/review.rs
+++ b/cargo-crev/src/review.rs
@@ -1,19 +1,17 @@
-use crate::{
-    edit,
-    opts::CargoOpts,
-    opts::{self, ReviewCrateSelector},
-    prelude::*,
-    term, url_to_status_str,
-};
-use anyhow::format_err;
-use crev_data::{
-    Rating, SOURCE_CRATES_IO,
-    proof::{self, ContentExt},
-};
-use crev_lib::{self, TrustProofType, local::Local};
-use std::{default::Default, fmt::Write};
+use std::default::Default;
+use std::fmt::Write;
 
-use crate::{repo::Repo, shared::*};
+use anyhow::format_err;
+use crev_data::proof::{self, ContentExt};
+use crev_data::{Rating, SOURCE_CRATES_IO};
+use crev_lib::local::Local;
+use crev_lib::{self, TrustProofType};
+
+use crate::opts::{self, CargoOpts, ReviewCrateSelector};
+use crate::prelude::*;
+use crate::repo::Repo;
+use crate::shared::*;
+use crate::{edit, term, url_to_status_str};
 
 /// Review a crate
 ///
@@ -40,22 +38,25 @@ pub fn create_review_proof(
     let crate_root = crate_.root();
     let effective_crate_version = crate_.version();
 
-    // We check the working directory because of how check_package_clean_state modifies the
-    // contents of the crate root, moving everything out of the directory.
-    // Therefore, it’s acceptable to run from the crate root directory or from outside the crate
-    // root directory, but not from a subdirectory of the crate root, because it may fail or
-    // misbehave on some platforms and is likely to exhibit confusing behaviour elsewhere.
+    // We check the working directory because of how check_package_clean_state
+    // modifies the contents of the crate root, moving everything out of the
+    // directory. Therefore, it’s acceptable to run from the crate root
+    // directory or from outside the crate root directory, but not from a
+    // subdirectory of the crate root, because it may fail or misbehave on some
+    // platforms and is likely to exhibit confusing behaviour elsewhere.
     //
-    // (While talking of problematic working directories: the "{crate_root}.crev.reviewed"
-    // directory would be bad, but is not trivially (in lines of code) to detect since
-    // OsStr::starts_with doesn’t exist; and symlinks can probably wreak havoc. But neither of
-    // these are likely to be encountered accidentally, so they’re not worth worrying about.)
+    // (While talking of problematic working directories: the
+    // "{crate_root}.crev.reviewed" directory would be bad, but is not trivially
+    // (in lines of code) to detect since OsStr::starts_with doesn’t exist; and
+    // symlinks can probably wreak havoc. But neither of these are likely to be
+    // encountered accidentally, so they’re not worth worrying about.)
     //
     // FIXME: in goto shells, cwd has already been changed to the GOTO_ORIGINAL_DIR,
-    // but we should actually be checking the process’s original cwd, either instead of or as well
-    // as, as that’s the cwd from the *user’s* perspective. As it stands, you could easily goto a
-    // crate, switch to a subdirectory, review, and either have fs errors (Windows, probably) or be
-    // returned to a deleted directory (most other OSes).
+    // but we should actually be checking the process’s original cwd, either instead
+    // of or as well as, as that’s the cwd from the *user’s* perspective. As it
+    // stands, you could easily goto a crate, switch to a subdirectory, review,
+    // and either have fs errors (Windows, probably) or be returned to a deleted
+    // directory (most other OSes).
     let cwd = std::env::current_dir()?;
     assert!(
         !cwd.starts_with(crate_root) || cwd == crate_root,

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -1,24 +1,22 @@
 // Here are the structs and functions which still need to be sorted
 //
-use crate::{
-    deps::scan::{self, RequiredDetails},
-    edit, opts,
-    opts::{CrateSelector, ReviewCrateSelector},
-    prelude::*,
-    repo::Repo,
-};
+use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::{env, io, process};
+
 use anyhow::{Context, Result, format_err};
-use crev_data::{SOURCE_CRATES_IO, proof, review::Package};
-use crev_lib::{self, ProofStore, ReviewMode, local::Local};
+use crev_data::review::Package;
+use crev_data::{SOURCE_CRATES_IO, proof};
+use crev_lib::local::Local;
+use crev_lib::{self, ProofStore, ReviewMode};
 use serde::Deserialize;
-use std::{
-    collections::HashSet,
-    env,
-    ffi::{OsStr, OsString},
-    io,
-    path::{Path, PathBuf},
-    process,
-};
+
+use crate::deps::scan::{self, RequiredDetails};
+use crate::opts::{CrateSelector, ReviewCrateSelector};
+use crate::prelude::*;
+use crate::repo::Repo;
+use crate::{edit, opts};
 
 /// Name of ENV with original location `crev goto` was called from
 pub const GOTO_ORIGINAL_DIR_ENV: &str = "CARGO_CREV_GOTO_ORIGINAL_DIR";
@@ -79,7 +77,8 @@ pub fn cargo_full_ignore_list(ignore_cargo_lock: bool) -> fnv::FnvHashSet<PathBu
     ignore_list
 }
 
-/// Ignore only the marker added by `cargo` after fully downloading and extracting crate
+/// Ignore only the marker added by `cargo` after fully downloading and
+/// extracting crate
 pub fn cargo_min_ignore_list() -> fnv::FnvHashSet<PathBuf> {
     let mut ignore_list = HashSet::default();
     ignore_list.insert(PathBuf::from(".cargo-ok"));
@@ -154,8 +153,8 @@ pub fn expand_crate_src(selector: &opts::CrateSelector) -> Result<()> {
     let crate_ = repo.get_crate(&crate_id)?;
     let crate_dir = crate_.root();
 
-    // TODO: discover all the entrypoint, iterate over them, take care of formatting and
-    // comments
+    // TODO: discover all the entrypoint, iterate over them, take care of formatting
+    // and comments
     println!(
         "{}",
         syn_inline_mod::parse_and_inline_modules(&crate_dir.join("src/lib.rs")).into_token_stream()
@@ -294,8 +293,9 @@ pub fn crate_open(
     let version = cargo_crate.version();
     let src_dir = cargo_crate.root();
 
-    // It's not safe to open Cargo's crate dir directly, because editor integration (like cargo check)
-    // could automatically start running crate's potentially malicious build script or proc macros.
+    // It's not safe to open Cargo's crate dir directly, because editor integration
+    // (like cargo check) could automatically start running crate's potentially
+    // malicious build script or proc macros.
     let dest_dir = local.sanitized_crate_copy(SOURCE_CRATES_IO, &name, version, src_dir)?;
 
     let open_cmd = match cmd {
@@ -441,8 +441,8 @@ pub fn check_package_clean_state(
 
     let digest_clean =
         crev_lib::get_recursive_digest_for_dir(crate_root, &cargo_min_ignore_list())?;
-    // if the `Cargo.lock` not exist in the clean package, we can ignore it being created
-    // in the reviewed version; that's normal
+    // if the `Cargo.lock` not exist in the clean package, we can ignore it being
+    // created in the reviewed version; that's normal
     let ignore_cargo_lock = !crate_root.join("Cargo.lock").exists();
     let digest_reviewed = crev_lib::get_recursive_digest_for_dir(
         &reviewed_pkg_dir,
@@ -533,8 +533,9 @@ pub fn run_diff(args: &opts::Diff) -> Result<std::process::ExitStatus> {
 
     match command.status() {
         Err(ref err) if err.kind() == io::ErrorKind::NotFound && cfg!(windows) => {
-            // On Windows, diff is likely available but *not* in %PATH.  Specifically, the git installer warns that
-            // adding *nix tools to %PATH% will change the behavior of some built in windows commands like "find", and
+            // On Windows, diff is likely available but *not* in %PATH.  Specifically, the
+            // git installer warns that adding *nix tools to %PATH% will change
+            // the behavior of some built in windows commands like "find", and
             // by default doesn't do this to avoid breaking anything.
 
             let program_files =

--- a/cargo-crev/src/term.rs
+++ b/cargo-crev/src/term.rs
@@ -1,13 +1,10 @@
+use std::env;
+use std::fmt::Arguments;
+use std::io::{self, Write};
+
 use crev_lib::VerificationStatus;
-use std::{
-    env,
-    fmt::Arguments,
-    io::{self, Write},
-};
-use term::{
-    self, StderrTerminal, StdoutTerminal,
-    color::{self, Color},
-};
+use term::color::{self, Color};
+use term::{self, StderrTerminal, StdoutTerminal};
 
 #[cfg(target_os = "macos")]
 use crate::creds;

--- a/cargo-crev/src/tokei.rs
+++ b/cargo-crev/src/tokei.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
 use std::path::Path;
+
 use tokei::{Config, LanguageType, Languages};
+
+use crate::prelude::*;
 
 pub fn get_rust_line_count(path: &Path) -> Result<usize> {
     let excluded = &["tests/", "examples/"];

--- a/cargo-crev/src/wot.rs
+++ b/cargo-crev/src/wot.rs
@@ -1,10 +1,13 @@
-use std::{io, io::Write as _};
+use std::io;
+use std::io::Write as _;
 
-use crate::{opts::WotOpts, term, url_to_status_str};
 use ::term::color::{BLUE, GREEN, RED, YELLOW};
 use anyhow::Result;
 use crev_wot::trust_set::TraverseLogItem::{Edge, Node};
 use itertools::Itertools;
+
+use crate::opts::WotOpts;
+use crate::{term, url_to_status_str};
 
 pub fn print_log(wot_opts: WotOpts) -> Result<()> {
     let mut term = term::Term::new();

--- a/cargo-crev/tests/clitest.rs
+++ b/cargo-crev/tests/clitest.rs
@@ -1,7 +1,10 @@
-use std::{ffi::*, io::Write, path::*, process::*};
+use std::ffi::*;
+use std::io::Write;
+use std::path::*;
+use std::process::*;
 
-/// Fixture: a package-review proof body (without the `----- BEGIN CREV PROOF -----`
-/// envelope or signature), as it would be produced by
+/// Fixture: a package-review proof body (without the `----- BEGIN CREV PROOF
+/// -----` envelope or signature), as it would be produced by
 /// `cargo crev review --no-store --print-unsigned > file`. Modeled after a
 /// real review from an existing proof repository.
 const UNSIGNED_REVIEW_FIXTURE: &str = r#"kind: package review

--- a/crev-common/rustfmt.toml
+++ b/crev-common/rustfmt.toml
@@ -1,2 +1,0 @@
-edition = "2018"
-# imports_granularity="Crate"

--- a/crev-common/src/fs.rs
+++ b/crev-common/src/fs.rs
@@ -1,7 +1,5 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 /// Move dir content from `from` dir to `to` dir
 pub fn move_dir_content(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/crev-common/src/lib.rs
+++ b/crev-common/src/lib.rs
@@ -9,18 +9,18 @@ pub mod fs;
 pub mod rand;
 pub mod serde;
 
-pub use crate::blake2b256::Blake2b256;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::process;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use blake2::{Digest, digest::FixedOutput};
-use std::{
-    collections::HashSet,
-    ffi::OsStr,
-    io::{self, BufRead, Write},
-    path::{Path, PathBuf},
-    process,
-};
+use blake2::Digest;
+use blake2::digest::FixedOutput;
+
+pub use crate::blake2b256::Blake2b256;
 
 #[derive(Debug, thiserror::Error)]
 pub enum YAMLIOError {
@@ -93,8 +93,8 @@ pub fn sanitize_name_for_fs(s: &str) -> PathBuf {
             'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => buffer.push(ch),
             _ => {
                 // Intentionally 'escaped' here:
-                //  '.' (path navigation attacks, and windows doesn't like leading/trailing '.'s)
-                //  ':' (windows reserves this for drive letters)
+                //  '.' (path navigation attacks, and windows doesn't like leading/trailing
+                // '.'s)  ':' (windows reserves this for drive letters)
                 //  '/', '\\' (path navigation attacks)
                 // Unicode, Punctuation (out of an abundance of cross platform paranoia)
                 buffer.push('_');
@@ -142,8 +142,8 @@ pub fn sanitize_url_for_fs(url: &str) -> PathBuf {
             'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => buffer.push(ch),
             _ => {
                 // Intentionally 'escaped' here:
-                //  '.' (path navigation attacks, and windows doesn't like leading/trailing '.'s)
-                //  ':' (windows reserves this for drive letters)
+                //  '.' (path navigation attacks, and windows doesn't like leading/trailing
+                // '.'s)  ':' (windows reserves this for drive letters)
                 //  '/', '\\' (path navigation attacks)
                 // Unicode, Punctuation (out of an abundance of cross platform paranoia)
                 buffer.push('_');
@@ -245,9 +245,10 @@ pub fn run_with_shell_cmd_custom(
     capture_stdout: bool,
 ) -> io::Result<std::process::Output> {
     if cfg!(windows) {
-        // cmd.exe /c "..." or cmd.exe /k "..." avoid unescaping "...", which makes .arg()'s built-in escaping problematic:
-        // https://github.com/rust-lang/rust/blob/379c380a60e7b3adb6c6f595222cbfa2d9160a20/src/libstd/sys/windows/process.rs#L488
-        // We can bypass this by (ab)using env vars.  Bonus points:  invalid unicode still works.
+        // cmd.exe /c "..." or cmd.exe /k "..." avoid unescaping "...", which makes
+        // .arg()'s built-in escaping problematic: https://github.com/rust-lang/rust/blob/379c380a60e7b3adb6c6f595222cbfa2d9160a20/src/libstd/sys/windows/process.rs#L488
+        // We can bypass this by (ab)using env vars.  Bonus points:  invalid unicode
+        // still works.
         let mut proc = process::Command::new("cmd.exe");
         if let Some(arg) = arg {
             proc.arg("/c").arg("%CREV_CMD% %CREV_ARG%");

--- a/crev-common/src/serde.rs
+++ b/crev-common/src/serde.rs
@@ -1,11 +1,14 @@
 // Oh dear, this module is called serde, and is in the root
 // so we have to import serde crate here
+use std::{error, fmt, io};
+
+use chrono::offset::FixedOffset;
+use chrono::prelude::*;
+use chrono::{self};
+use hex::{self, FromHex, FromHexError};
 use serde;
 
 use self::serde::Deserialize;
-use chrono::{self, offset::FixedOffset, prelude::*};
-use hex::{self, FromHex, FromHexError};
-use std::{error, fmt, io};
 
 // {{{ Serde serialization
 pub trait MyTryFromBytes: Sized {

--- a/crev-data/rustfmt.toml
+++ b/crev-data/rustfmt.toml
@@ -1,2 +1,0 @@
-edition = "2018"
-# imports_granularity="Crate"

--- a/crev-data/src/digest.rs
+++ b/crev-data/src/digest.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-/// This is a cryptographic hash of everything in a crate, which reliably identifies its exact source code
+/// This is a cryptographic hash of everything in a crate, which reliably
+/// identifies its exact source code
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Digest([u8; 32]);
 

--- a/crev-data/src/id.rs
+++ b/crev-data/src/id.rs
@@ -1,16 +1,15 @@
-use crate::{
-    Url,
-    proof::{self, ContentExt, OverrideItem},
-};
-use crev_common::{
-    self,
-    serde::{as_base64, from_base64},
-};
+use std::convert::TryFrom;
+use std::fmt;
+
+use crev_common::serde::{as_base64, from_base64};
+use crev_common::{self};
 use derive_builder::Builder;
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
+
+use crate::Url;
+use crate::proof::{self, ContentExt, OverrideItem};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IdType {

--- a/crev-data/src/level.rs
+++ b/crev-data/src/level.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Default)]
 #[serde(rename_all = "lowercase")]

--- a/crev-data/src/lib.rs
+++ b/crev-data/src/lib.rs
@@ -14,20 +14,17 @@ pub mod proof;
 pub mod url;
 #[macro_use]
 pub mod util;
-use crate::{id::IdError, proof::content::ValidationError};
 pub use semver::Version;
 
-pub use crate::{
-    digest::Digest,
-    id::{Id, PublicId, UnlockedId},
-    level::Level,
-    proof::{
-        review,
-        review::{Rating, Review},
-        trust::TrustLevel,
-    },
-    url::Url,
-};
+pub use crate::digest::Digest;
+use crate::id::IdError;
+pub use crate::id::{Id, PublicId, UnlockedId};
+pub use crate::level::Level;
+use crate::proof::content::ValidationError;
+pub use crate::proof::review;
+pub use crate::proof::review::{Rating, Review};
+pub use crate::proof::trust::TrustLevel;
+pub use crate::url::Url;
 
 /// It's just a string. See [`SOURCE_CRATES_IO`]
 pub type RegistrySource<'a> = &'a str;

--- a/crev-data/src/proof/content.rs
+++ b/crev-data/src/proof/content.rs
@@ -1,12 +1,14 @@
-use crate::{Error, ParseError, Result, proof, proof::Proof};
-use chrono::{self, prelude::*};
-use crev_common::{
-    self,
-    serde::{as_base64, as_rfc3339_fixed, from_base64, from_rfc3339_fixed},
-};
+use std::{fmt, io};
+
+use chrono::prelude::*;
+use chrono::{self};
+use crev_common::serde::{as_base64, as_rfc3339_fixed, from_base64, from_rfc3339_fixed};
+use crev_common::{self};
 use derive_builder::Builder;
 use serde::{self, Deserialize, Serialize};
-use std::{fmt, io};
+
+use crate::proof::Proof;
+use crate::{Error, ParseError, Result, proof};
 
 pub type Date = chrono::DateTime<FixedOffset>;
 

--- a/crev-data/src/proof/mod.rs
+++ b/crev-data/src/proof/mod.rs
@@ -1,19 +1,20 @@
 //! Some common stuff for both Review and Trust Proofs
 
-pub use crate::proof::content::{
-    Common, CommonOps, Content, ContentDeserialize, ContentExt, ContentWithDraft, Draft, WithReview,
-};
-use crate::{Error, ParseError, PublicId, Result};
-use chrono::{self, prelude::*};
+use std::fmt;
+use std::io::{self, BufRead};
+
+use chrono::prelude::*;
+use chrono::{self};
 pub use package_info::*;
 pub use review::{Code as CodeReview, Package as PackageReview, *};
 pub use revision::*;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt,
-    io::{self, BufRead},
-};
 pub use trust::*;
+
+pub use crate::proof::content::{
+    Common, CommonOps, Content, ContentDeserialize, ContentExt, ContentWithDraft, Draft, WithReview,
+};
+use crate::{Error, ParseError, PublicId, Result};
 
 pub mod content;
 pub mod package_info;
@@ -110,7 +111,8 @@ impl Proof {
         &self.digest
     }
 
-    /// Read the YAML with serde, you should already know which type to expect from context
+    /// Read the YAML with serde, you should already know which type to expect
+    /// from context
     pub fn parse_content<T: ContentDeserialize>(&self) -> std::result::Result<T, Error> {
         T::deserialize_from(self.body.as_bytes())
     }

--- a/crev-data/src/proof/package_info.rs
+++ b/crev-data/src/proof/package_info.rs
@@ -1,9 +1,9 @@
-use crate::proof;
-
 use crev_common::serde::{as_base64, from_base64};
 use derive_builder::Builder;
 pub use semver::Version;
 use serde::{Deserialize, Serialize};
+
+use crate::proof;
 
 #[derive(Clone, Debug, Builder, Serialize, Deserialize, PartialEq, Hash, Eq)]
 pub struct PackageId {

--- a/crev-data/src/proof/review/code.rs
+++ b/crev-data/src/proof/review/code.rs
@@ -1,15 +1,15 @@
-use crate::{
-    ParseError, Result, proof, proof::content::ValidationResult, serde_content_serialize,
-    serde_draft_serialize,
-};
-use crev_common::{
-    self,
-    serde::{as_base64, from_base64},
-};
+use std::default::Default;
+use std::path::PathBuf;
+use std::{self, fmt};
+
+use crev_common::serde::{as_base64, from_base64};
+use crev_common::{self};
 use derive_builder::Builder;
 use proof::{CommonOps, Content};
 use serde::{Deserialize, Serialize};
-use std::{self, default::Default, fmt, path::PathBuf};
+
+use crate::proof::content::ValidationResult;
+use crate::{ParseError, Result, proof, serde_content_serialize, serde_draft_serialize};
 
 const CURRENT_CODE_REVIEW_PROOF_SERIALIZATION_VERSION: i64 = -1;
 

--- a/crev-data/src/proof/review/mod.rs
+++ b/crev-data/src/proof/review/mod.rs
@@ -1,10 +1,11 @@
-use crate::level::Level;
+use std::default::Default;
+
 pub use code::*;
 use derive_builder::Builder;
-pub use package::Draft;
-pub use package::*;
+pub use package::{Draft, *};
 use serde::{Deserialize, Serialize};
-use std::default::Default;
+
+use crate::level::Level;
 
 pub mod code;
 pub mod package;

--- a/crev-data/src/proof/review/package.rs
+++ b/crev-data/src/proof/review/package.rs
@@ -1,23 +1,18 @@
-use crate::{
-    Error, Level, ParseError,
-    proof::{
-        self, OverrideItem, OverrideItemDraft,
-        content::{OriginalReference, ValidationError, ValidationResult},
-    },
-    serde_content_serialize, serde_draft_serialize,
-};
+use std::collections::HashSet;
+use std::default::Default;
+use std::fmt::{self, Debug};
+use std::ops;
+
 use crev_common::{self, is_equal_default, is_set_empty, is_vec_empty};
 use derive_builder::Builder;
 use proof::{CommonOps, Content};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashSet,
-    default::Default,
-    fmt::{self, Debug},
-    ops,
-};
 use typed_builder::TypedBuilder;
+
+use crate::proof::content::{OriginalReference, ValidationError, ValidationResult};
+use crate::proof::{self, OverrideItem, OverrideItemDraft};
+use crate::{Error, Level, ParseError, serde_content_serialize, serde_draft_serialize};
 
 const CURRENT_PACKAGE_REVIEW_PROOF_SERIALIZATION_VERSION: i64 = -1;
 
@@ -171,7 +166,8 @@ impl Package {
 
     pub fn ensure_kind_is_backfilled(&mut self) {
         if self.common.kind.is_none() {
-            // backfill "kind" for old reviews. Don't use common().kind() here, it will panic.
+            // backfill "kind" for old reviews. Don't use common().kind() here, it will
+            // panic.
             self.common.kind = Some(self.kind().to_string());
         }
     }

--- a/crev-data/src/proof/revision.rs
+++ b/crev-data/src/proof/revision.rs
@@ -1,6 +1,7 @@
-use crate::proof;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+
+use crate::proof;
 
 #[derive(Clone, Debug, Builder, Serialize, Deserialize)]
 pub struct Revision {

--- a/crev-data/src/proof/trust.rs
+++ b/crev-data/src/proof/trust.rs
@@ -1,15 +1,12 @@
-use crate::{
-    Error, Level, ParseError, Result,
-    proof::{self, CommonOps, Content, content::ValidationResult},
-    serde_content_serialize, serde_draft_serialize,
-};
+use std::fmt;
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use std::fmt;
-
 use super::{OverrideItem, OverrideItemDraft};
+use crate::proof::content::ValidationResult;
+use crate::proof::{self, CommonOps, Content};
+use crate::{Error, Level, ParseError, Result, serde_content_serialize, serde_draft_serialize};
 
 const CURRENT_TRUST_PROOF_SERIALIZATION_VERSION: i64 = -1;
 

--- a/crev-data/src/tests.rs
+++ b/crev-data/src/tests.rs
@@ -1,10 +1,11 @@
-use crate::{
-    Error, Result, Url,
-    id::UnlockedId,
-    proof::{self, Content, ContentExt, ContentWithDraft, Proof},
-};
+use std::default::Default;
+use std::path::PathBuf;
+
 use semver::Version;
-use std::{default::Default, path::PathBuf};
+
+use crate::id::UnlockedId;
+use crate::proof::{self, Content, ContentExt, ContentWithDraft, Proof};
+use crate::{Error, Result, Url};
 
 #[test]
 pub fn signed_parse() -> Result<()> {

--- a/crev-data/src/util/mod.rs
+++ b/crev-data/src/util/mod.rs
@@ -1,5 +1,6 @@
-use rand::{self, Rng};
 use std::fmt;
+
+use rand::{self, Rng};
 
 #[must_use]
 pub fn random_id_str() -> String {

--- a/crev-lib/rustfmt.toml
+++ b/crev-lib/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2018"
-# imports_granularity="Crate"
-

--- a/crev-lib/src/activity.rs
+++ b/crev-lib/src/activity.rs
@@ -4,10 +4,8 @@
 //! Eg. when user reviews a package we record details
 //! and  we  can warn them if they attempt to create
 //! a proof review which they haven't previously reviewed.
-use crev_common::{
-    self,
-    serde::{as_rfc3339_fixed, from_rfc3339_fixed},
-};
+use crev_common::serde::{as_rfc3339_fixed, from_rfc3339_fixed};
+use crev_common::{self};
 use crev_data::Version;
 use serde::{Deserialize, Serialize};
 

--- a/crev-lib/src/id.rs
+++ b/crev-lib/src/id.rs
@@ -1,15 +1,18 @@
-//! `LockedId` is for you, the local crev user. `Id` is for identifying other users.
+//! `LockedId` is for you, the local crev user. `Id` is for identifying other
+//! users.
 
-use crate::{Error, Result};
+use std::io::BufReader;
+use std::path::Path;
+use std::{self, fmt};
+
 use aes_siv::KeyInit;
 use argon2::{self, Config};
-use crev_common::{
-    rand::random_vec,
-    serde::{as_base64, from_base64},
-};
+use crev_common::rand::random_vec;
+use crev_common::serde::{as_base64, from_base64};
 use crev_data::id::{PublicId, UnlockedId};
 use serde::{Deserialize, Serialize};
-use std::{self, fmt, io::BufReader, path::Path};
+
+use crate::{Error, Result};
 
 const CURRENT_LOCKED_ID_SERIALIZATION_VERSION: i64 = -1;
 
@@ -101,7 +104,8 @@ impl LockedId {
 
         let seal_nonce = random_vec(32);
         let sealed_secret_key = {
-            use aes_siv::{aead::generic_array::GenericArray, siv::IV_SIZE};
+            use aes_siv::aead::generic_array::GenericArray;
+            use aes_siv::siv::IV_SIZE;
 
             let secret = unlocked_id.keypair.secret.as_bytes();
             let mut siv = aes_siv::siv::Aes256Siv::new(&GenericArray::clone_from_slice(&pwhash));
@@ -131,7 +135,8 @@ impl LockedId {
         })
     }
 
-    /// Extract only the public identity part from all data. Useful for displaying user's identity.
+    /// Extract only the public identity part from all data. Useful for
+    /// displaying user's identity.
     #[must_use]
     pub fn to_public_id(&self) -> PublicId {
         PublicId::new_from_pubkey(self.public_key.clone(), self.url.clone())
@@ -201,7 +206,9 @@ impl LockedId {
                 argon2::hash_raw(passphrase.as_bytes(), &passphrase_config.salt, &config)?;
 
             let secret_key = {
-                use aes_siv::{Tag, aead::generic_array::GenericArray, siv::IV_SIZE};
+                use aes_siv::Tag;
+                use aes_siv::aead::generic_array::GenericArray;
+                use aes_siv::siv::IV_SIZE;
 
                 let mut siv =
                     aes_siv::siv::Aes256Siv::new(&GenericArray::clone_from_slice(&passphrase_hash));
@@ -227,13 +234,15 @@ impl LockedId {
         }
     }
 
-    /// Used for temporary/default identity, but obviously not very secure to store
+    /// Used for temporary/default identity, but obviously not very secure to
+    /// store
     #[must_use]
     pub fn has_no_passphrase(&self) -> bool {
         self.passphrase_config.iterations == 1 && self.to_unlocked("").is_ok()
     }
 
-    /// Config for empty passphrase. User chose no security, so they're getting none.
+    /// Config for empty passphrase. User chose no security, so they're getting
+    /// none.
     fn weak_passphrase_config() -> Config<'static> {
         Config {
             variant: argon2::Variant::Argon2id,

--- a/crev-lib/src/lib.rs
+++ b/crev-lib/src/lib.rs
@@ -13,26 +13,22 @@ pub mod proof;
 pub mod repo;
 pub mod staging;
 pub mod util;
-pub use crate::local::Local;
+use std::collections::{HashMap, HashSet};
+use std::error::Error as _;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
 pub use activity::{ReviewActivity, ReviewMode};
-use crev_data::{
-    self, Digest, Id, RegistrySource, Version,
-    id::IdError,
-    proof::{
-        CommonOps,
-        review::{self, Rating},
-        trust::TrustLevel,
-    },
-};
+use crev_data::id::IdError;
+use crev_data::proof::CommonOps;
+use crev_data::proof::review::{self, Rating};
+use crev_data::proof::trust::TrustLevel;
+use crev_data::{self, Digest, Id, RegistrySource, Version};
 use crev_wot::PkgVersionReviewId;
 pub use crev_wot::TrustDistanceParams;
 use log::warn;
-use std::error::Error as _;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    path::{Path, PathBuf},
-};
+
+pub use crate::local::Local;
 
 /// Failures that can happen in this library
 #[derive(Debug, thiserror::Error)]
@@ -97,7 +93,8 @@ pub enum Error {
     #[error("Id not specified and current id not set")]
     IDNotSpecifiedAndCurrentIDNotSet,
 
-    /// crev uses git checkouts, and needs to know their URLs. Delete the repo and try again.
+    /// crev uses git checkouts, and needs to know their URLs. Delete the repo
+    /// and try again.
     #[error("origin has no url at {}", _0.display())]
     OriginHasNoURL(Box<Path>),
 
@@ -185,7 +182,8 @@ pub enum Error {
 /// [`crate::Error`]
 type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Trait representing a place that can keep proofs (all reviews and trust proofs)
+/// Trait representing a place that can keep proofs (all reviews and trust
+/// proofs)
 ///
 /// See [`::crev_wot::ProofDb`] and [`crate::Local`].
 ///
@@ -459,7 +457,8 @@ pub fn find_latest_trusted_version(
         .map(|review| review.package.id.version.clone())
 }
 
-/// Check whether code at this path has reviews, and the reviews meet the requirements.
+/// Check whether code at this path has reviews, and the reviews meet the
+/// requirements.
 ///
 /// See also `verify_package_digest`
 pub fn dir_or_git_repo_verify(
@@ -483,7 +482,8 @@ pub fn dir_or_git_repo_verify(
     ))
 }
 
-/// Check whether code at this path has reviews, and the reviews meet the requirements
+/// Check whether code at this path has reviews, and the reviews meet the
+/// requirements
 ///
 /// Same as `dir_or_git_repo_verify`, except it doesn't handle .git dirs
 pub fn dir_verify(
@@ -503,7 +503,8 @@ pub fn dir_verify(
     ))
 }
 
-/// Scan dir and hash everything in it, to get a unique identifier of the package's source code
+/// Scan dir and hash everything in it, to get a unique identifier of the
+/// package's source code
 pub fn get_dir_digest(path: &Path, ignore_list: &fnv::FnvHashSet<PathBuf>) -> Result<Digest> {
     Ok(Digest::from_bytes(&util::get_recursive_digest_for_dir(path, ignore_list)?).unwrap())
 }

--- a/crev-lib/src/local.rs
+++ b/crev-lib/src/local.rs
@@ -1,32 +1,28 @@
-use crate::{
-    Error, ProofStore, Result, Warning,
-    activity::{LatestReviewActivity, ReviewActivity},
-    id::{self, LockedId, PassphraseFn},
-    util::{self, git::is_unrecoverable},
-};
-use crev_common::{
-    self, sanitize_name_for_fs, sanitize_url_for_fs,
-    serde::{as_base64, from_base64},
-};
-use crev_data::{
-    Id, PublicId, RegistrySource, Url,
-    id::UnlockedId,
-    proof::{self, OverrideItem, trust::TrustLevel},
-};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+
+use crev_common::serde::{as_base64, from_base64};
+use crev_common::{self, sanitize_name_for_fs, sanitize_url_for_fs};
+use crev_data::id::UnlockedId;
+use crev_data::proof::trust::TrustLevel;
+use crev_data::proof::{self, OverrideItem};
+use crev_data::{Id, PublicId, RegistrySource, Url};
 use default::default;
 use directories::ProjectDirs;
 use log::{debug, error, info, warn};
 use resiter::{FilterMap, Map};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashSet,
-    ffi::OsString,
-    fs,
-    io::{BufRead, BufReader, Write},
-    path::{Path, PathBuf},
-    str::FromStr,
-    sync::{Arc, Mutex},
-};
+
+use crate::activity::{LatestReviewActivity, ReviewActivity};
+use crate::id::{self, LockedId, PassphraseFn};
+use crate::util::git::is_unrecoverable;
+use crate::util::{self};
+use crate::{Error, ProofStore, Result, Warning};
 
 const CURRENT_USER_CONFIG_SERIALIZATION_VERSION: i64 = -1;
 
@@ -530,8 +526,8 @@ impl Local {
         }
     }
 
-    /// Changes the repo URL for the ID. Adopts existing temporary/local repo if any.
-    /// Previous remote URL is abandoned.
+    /// Changes the repo URL for the ID. Adopts existing temporary/local repo if
+    /// any. Previous remote URL is abandoned.
     /// For crev id set-url command.
     pub fn change_locked_id_url(
         &self,
@@ -561,7 +557,8 @@ impl Local {
         id.url = Some(new_url);
         self.save_locked_id(id)?;
 
-        // commit uncommitted changes, if there are any. Otherwise the next pull may fail
+        // commit uncommitted changes, if there are any. Otherwise the next pull may
+        // fail
         let _ = self.proof_dir_commit("Setting up new CrevID URL");
         let _ = self.run_git(
             vec!["pull".into(), "--rebase".into(), "-Xours".into()],
@@ -601,7 +598,8 @@ impl Local {
         Ok(())
     }
 
-    /// Git clone or init new remote Github crev-proof repo for the current user.
+    /// Git clone or init new remote Github crev-proof repo for the current
+    /// user.
     ///
     /// Saves to `user_proofs_path`, so it's trusted as user's own proof repo.
     pub fn clone_proof_dir_from_git(
@@ -821,13 +819,15 @@ impl Local {
         Ok(from_id.create_trust_proof(&public_ids, trust_level, override_)?)
     }
 
-    /// Fetch other people's proof repository from a git URL, into the current database on disk
+    /// Fetch other people's proof repository from a git URL, into the current
+    /// database on disk
     pub fn fetch_url(&self, url: &str) -> Result<()> {
         let mut db = self.load_db()?;
         self.fetch_url_into(url, &mut db)
     }
 
-    /// Fetch other people's proof repository from a git URL, directly into the given db (and disk too)
+    /// Fetch other people's proof repository from a git URL, directly into the
+    /// given db (and disk too)
     pub fn fetch_url_into(&self, url: &str, db: &mut crev_wot::ProofDB) -> Result<()> {
         info!("Fetching {url}... ");
         let dir = self.fetch_remote_git(url)?;
@@ -863,7 +863,8 @@ impl Local {
             if let Some(for_id) = self.get_for_id_from_str_opt(for_id)? {
                 db.calculate_trust_set(&for_id, params)
             } else {
-                // when running without an id (explicit, or current), just use an empty trust set
+                // when running without an id (explicit, or current), just use an empty trust
+                // set
                 crev_wot::TrustSet::default()
             },
         )
@@ -1030,7 +1031,8 @@ impl Local {
         Ok(new_path)
     }
 
-    /// `LocalUser` if it's current user's URL, or `crev_wot::FetchSource` for the URL.
+    /// `LocalUser` if it's current user's URL, or `crev_wot::FetchSource` for
+    /// the URL.
     fn get_fetch_source_for_url(&self, url: Url) -> Result<crev_wot::FetchSource> {
         if let Ok(own_url) = self.get_cur_url()
             && own_url == url

--- a/crev-lib/src/proof.rs
+++ b/crev-lib/src/proof.rs
@@ -1,6 +1,8 @@
-use crate::{ProofStore, TrustLevel};
-use crev_data::proof::{self, CommonOps};
 use std::path::PathBuf;
+
+use crev_data::proof::{self, CommonOps};
+
+use crate::{ProofStore, TrustLevel};
 
 fn proof_store_names(proof: &proof::Proof) -> (&str, Option<&str>) {
     match proof.kind() {

--- a/crev-lib/src/repo/mod.rs
+++ b/crev-lib/src/repo/mod.rs
@@ -1,12 +1,12 @@
-use crate::{Error, Result, local::Local, util, verify_package_digest};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use crev_data::{Digest, proof};
 use serde::{Deserialize, Serialize};
 
-use std::{
-    collections::HashSet,
-    fs,
-    path::{Path, PathBuf},
-};
+use crate::local::Local;
+use crate::{Error, Result, util, verify_package_digest};
 
 pub mod staging;
 

--- a/crev-lib/src/repo/staging.rs
+++ b/crev-lib/src/repo/staging.rs
@@ -1,12 +1,12 @@
-use crate::{Error, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 use crev_data::proof;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    fs,
-    io::Write,
-    path::{Path, PathBuf},
-};
+
+use crate::{Error, Result};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StagingPathInfo {

--- a/crev-lib/src/tests.rs
+++ b/crev-lib/src/tests.rs
@@ -1,11 +1,12 @@
-use super::*;
-use crev_data::{
-    Level, UnlockedId, Url,
-    proof::{ContentExt, PackageVersionId},
-};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use crev_data::proof::{ContentExt, PackageVersionId};
+use crev_data::{Level, UnlockedId, Url};
 use crev_wot::{FetchSource, ProofDB};
 use default::default;
-use std::{str::FromStr, sync::Arc};
+
+use super::*;
 
 // Basic lifetime of an `LockedId`:
 //

--- a/crev-lib/src/util/git.rs
+++ b/crev-lib/src/util/git.rs
@@ -1,7 +1,9 @@
-use crate::Result;
+use std::path::Path;
+
 use git2::{ErrorClass, ErrorCode};
 use log::debug;
-use std::path::Path;
+
+use crate::Result;
 
 #[derive(PartialEq, Debug, Default)]
 pub struct GitUrlComponents {

--- a/crev-lib/src/util/mod.rs
+++ b/crev-lib/src/util/mod.rs
@@ -1,10 +1,11 @@
-use crev_common::sanitize_name_for_fs;
-pub use crev_common::{run_with_shell_cmd, store_str_to_file, store_to_file_with};
-use crev_data::proof;
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
+
+use crev_common::sanitize_name_for_fs;
+pub use crev_common::{run_with_shell_cmd, store_str_to_file, store_to_file_with};
+use crev_data::proof;
 
 pub mod git;
 
@@ -19,7 +20,8 @@ pub fn get_documentation_for(content: &impl proof::Content) -> &'static str {
 
 #[cfg(target_family = "unix")]
 pub fn chmod_path_to_600(path: &Path) -> io::Result<()> {
-    use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+    use std::fs::Permissions;
+    use std::os::unix::fs::PermissionsExt;
 
     std::fs::set_permissions(path, Permissions::from_mode(0o600))
 }
@@ -133,7 +135,8 @@ fn mark_dangerous_name(
             ));
             alt
         }
-        // Are there legit use-cases for Unicode names? Killing it avoids risk of homograph or BIDI spoofing
+        // Are there legit use-cases for Unicode names? Killing it avoids risk of homograph or BIDI
+        // spoofing
         n if n.as_bytes().iter().any(|&c| {
             c < b' '
                 || c >= 0x7F
@@ -155,7 +158,8 @@ fn mark_dangerous_name(
     }
 }
 
-/// Make a copy of the directory, but skip or rename all files that are potentially dangerous in Cargo projects
+/// Make a copy of the directory, but skip or rename all files that are
+/// potentially dangerous in Cargo projects
 pub fn copy_dir_sanitized(
     src_dir: &Path,
     dest_dir: &Path,

--- a/flake.nix
+++ b/flake.nix
@@ -141,17 +141,11 @@
       in
       {
         packages = {
+          treefmt = treefmt;
           default = multiBuild.cargo-crev;
           cargo-crev = multiBuild.cargo-crev;
 
-          ci = {
-            cargo-crev = multiBuild.cargo-crev;
-            workspace = multiBuild.workspace;
-            workspaceDeps = multiBuild.workspaceDeps;
-            clippy = multiBuild.clippy;
-            treefmt = fmtCheck;
-            tests = multiBuild.tests;
-          };
+
 
           container = {
             cargo-crev = cargo-crev-container;

--- a/flake.nix
+++ b/flake.nix
@@ -145,8 +145,6 @@
           default = multiBuild.cargo-crev;
           cargo-crev = multiBuild.cargo-crev;
 
-
-
           container = {
             cargo-crev = cargo-crev-container;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,14 @@
             github.ci.buildOutputs = [ ".#ci.${projectName}" ];
             just.importPaths = [ "justfile.custom.just" ];
             just.rules.watch.enable = false;
+            toolchain.components = [
+              "rustc"
+              "cargo"
+              "clippy"
+              "rust-analyzer"
+              "rust-src"
+              "rustfmt"
+            ];
           };
         };
 
@@ -97,12 +105,31 @@
               cargoArtifacts = workspaceDeps;
             };
 
+            cargoFmt = craneLib.cargoFmt { };
+
             cargo-crev = craneLib.buildPackage {
               cargoArtifacts = workspaceDeps;
               cargoExtraArgs = "--bin cargo-crev";
             };
           }
         );
+
+        treefmt =
+          pkgs.runCommand "treefmt-check"
+            {
+              nativeBuildInputs = [
+                pkgs.treefmt
+                pkgs.nixfmt-rfc-style
+                pkgs.rustfmt
+              ];
+              src = self;
+            }
+            ''
+              cp -r $src work && chmod -R u+w work
+              cd work
+              treefmt --ci
+              touch $out
+            '';
 
         cargo-crev-container = pkgs.dockerTools.buildLayeredImage {
           name = projectName;
@@ -122,6 +149,7 @@
             workspace = multiBuild.workspace;
             workspaceDeps = multiBuild.workspaceDeps;
             clippy = multiBuild.clippy;
+            treefmt = fmtCheck;
             tests = multiBuild.tests;
           };
 


### PR DESCRIPTION
Unpinned formatting check just started failing because of new Rust. Might as well use Nix-pinned one and have it in sync with Nix dev env.