### PR TITLE
fix: parse dirty Cargo VCS metadata

### DIFF
--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -52,8 +52,17 @@ impl VcsInfoJson {
 
         if path.exists() {
             let txt = std::fs::read_to_string(&path)?;
-            let info: VcsInfoJson = serde_json::from_str(&txt)?;
-            Ok(Some(info))
+            match serde_json::from_str(&txt) {
+                Ok(info) => Ok(Some(info)),
+                Err(err) => {
+                    eprintln!(
+                        "Warning: ignoring unparsable {} at {}: {err}",
+                        VCS_INFO_JSON_FILE,
+                        path.display()
+                    );
+                    Ok(None)
+                }
+            }
         } else {
             Ok(None)
         }
@@ -95,6 +104,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(vcs_info_to_revision_string(Some(vcs)), "abc");
+    }
+
+    #[test]
+    fn vcs_info_read_ignores_parse_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(VCS_INFO_JSON_FILE), "invalid json").unwrap();
+
+        let vcs = VcsInfoJson::read_from_crate_dir(dir.path()).unwrap();
+
+        assert!(vcs.is_none());
     }
 }
 

--- a/cargo-crev/src/shared.rs
+++ b/cargo-crev/src/shared.rs
@@ -42,9 +42,8 @@ pub fn vcs_info_to_revision_string(vcs: Option<VcsInfoJson>) -> String {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub enum VcsInfoJsonGit {
-    #[serde(rename = "sha1")]
-    Sha1(String),
+pub struct VcsInfoJsonGit {
+    sha1: String,
 }
 
 impl VcsInfoJson {
@@ -60,8 +59,42 @@ impl VcsInfoJson {
         }
     }
     fn get_git_revision(&self) -> String {
-        let VcsInfoJsonGit::Sha1(ref s) = self.git;
-        s.to_string()
+        self.git.sha1.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vcs_info_parses_sha1() {
+        let vcs: VcsInfoJson = serde_json::from_str(
+            r#"{
+                "git": {
+                    "sha1": "abc"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(vcs_info_to_revision_string(Some(vcs)), "abc");
+    }
+
+    #[test]
+    fn vcs_info_parses_dirty_and_path_in_vcs() {
+        let vcs: VcsInfoJson = serde_json::from_str(
+            r#"{
+                "git": {
+                    "sha1": "abc",
+                    "dirty": true
+                },
+                "path_in_vcs": ""
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(vcs_info_to_revision_string(Some(vcs)), "abc");
     }
 }
 


### PR DESCRIPTION
*PR published by Tau/OpenAI*

### Summary

Fixes #876 by making `.cargo_vcs_info.json` handling tolerate Cargo metadata changes. `cargo crev review indicatif` failed because the parser modeled `git` as a single-variant enum and rejected objects with extra fields like `git.dirty`; now known formats parse correctly, and future unparsable metadata is treated as missing VCS revision data instead of aborting the review.

### Details

The VCS metadata parser now models the `git` object as a struct containing the `sha1` field. Serde ignores unknown fields by default, so this keeps the existing revision extraction behavior while accepting Cargo metadata from crates like `indicatif 0.18.4`.

If `.cargo_vcs_info.json` exists but cannot be parsed due to a future format change, cargo-crev now prints a warning and continues without VCS revision info. Filesystem read errors are still propagated.

Added focused tests for:

- old sha1-only metadata
- metadata with `git.dirty` and `path_in_vcs`
- invalid metadata being ignored with `None`

Fixes #876.
